### PR TITLE
A faster multiplication with more ymm1; Also make the mask kernel more generic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ script:
   - |
       travis-cargo build &&
       travis-cargo test &&
+      travis-cargo test -- --release &&
+      travis-cargo test &&
       travis-cargo bench -- --no-run &&
       travis-cargo doc
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ after_success:
   # upload the documentation (GH_TOKEN from env)
   - travis-cargo --only nightly doc-upload
 
+branches:
+  only:
+    - master
+
 env:
   global:
     # override the default `--features unstable` used for the nightly branch (optional)

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -15,6 +15,9 @@ impl GemmKernel for Gemm {
     fn nr() -> usize { 4 }
 
     #[inline(always)]
+    fn align_to() -> usize { 0 }
+
+    #[inline(always)]
     fn nc() -> usize { archparam::D_NC }
     #[inline(always)]
     fn kc() -> usize { archparam::D_KC }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -3,6 +3,11 @@
 pub trait GemmKernel {
     type Elem: Copy;
 
+    /// align inputs to this
+    ///
+    /// NOTE: Not yet used.
+    fn align_to() -> usize;
+
     /// Kernel rows
     fn mr() -> usize;
     /// Kernel cols

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -1,7 +1,7 @@
 
 /// General matrix multiply kernel
 pub trait GemmKernel {
-    type Elem: Copy;
+    type Elem: Element;
 
     /// align inputs to this
     ///
@@ -36,16 +36,6 @@ pub trait GemmKernel {
         b: *const Self::Elem,
         beta: Self::Elem,
         c: *mut Self::Elem, rsc: isize, csc: isize);
-
-    /// Masked (partial) kernel
-    unsafe fn kernel_masked(
-        k: usize,
-        alpha: Self::Elem,
-        a: *const Self::Elem,
-        b: *const Self::Elem,
-        beta: Self::Elem,
-        c: *mut Self::Elem, rsc: isize, csc: isize,
-        nr_: usize, mr_: usize);
 }
 
 pub trait Element : Copy {
@@ -53,6 +43,7 @@ pub trait Element : Copy {
     fn one() -> Self;
     fn is_zero(&self) -> bool;
     fn scale_by(&mut self, x: Self);
+    fn scaled_add(&mut self, alpha: Self, a: Self);
 }
 
 impl Element for f32 {
@@ -62,6 +53,9 @@ impl Element for f32 {
     fn scale_by(&mut self, x: Self) {
         *self *= x;
     }
+    fn scaled_add(&mut self, alpha: Self, a: Self) {
+        *self += alpha * a;
+    }
 }
 
 impl Element for f64 {
@@ -70,5 +64,8 @@ impl Element for f64 {
     fn is_zero(&self) -> bool { *self == 0. }
     fn scale_by(&mut self, x: Self) {
         *self *= x;
+    }
+    fn scaled_add(&mut self, alpha: Self, a: Self) {
+        *self += alpha * a;
     }
 }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -47,3 +47,28 @@ pub trait GemmKernel {
         c: *mut Self::Elem, rsc: isize, csc: isize,
         nr_: usize, mr_: usize);
 }
+
+pub trait Element : Copy {
+    fn zero() -> Self;
+    fn one() -> Self;
+    fn is_zero(&self) -> bool;
+    fn scale_by(&mut self, x: Self);
+}
+
+impl Element for f32 {
+    fn zero() -> Self { 0. }
+    fn one() -> Self { 1. }
+    fn is_zero(&self) -> bool { *self == 0. }
+    fn scale_by(&mut self, x: Self) {
+        *self *= x;
+    }
+}
+
+impl Element for f64 {
+    fn zero() -> Self { 0. }
+    fn one() -> Self { 1. }
+    fn is_zero(&self) -> bool { *self == 0. }
+    fn scale_by(&mut self, x: Self) {
+        *self *= x;
+    }
+}

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -15,6 +15,9 @@ impl GemmKernel for Gemm {
     fn nr() -> usize { 4 }
 
     #[inline(always)]
+    fn align_to() -> usize { 0 }
+
+    #[inline(always)]
     fn nc() -> usize { archparam::S_NC }
     #[inline(always)]
     fn kc() -> usize { archparam::S_KC }

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -34,18 +34,6 @@ impl GemmKernel for Gemm {
         c: *mut T, rsc: isize, csc: isize) {
         kernel_4x4(k, alpha, a, b, beta, c, rsc, csc)
     }
-
-    #[inline(always)]
-    unsafe fn kernel_masked(
-        k: usize,
-        alpha: T,
-        a: *const T,
-        b: *const T,
-        beta: T,
-        c: *mut T, rsc: isize, csc: isize,
-        mr_: usize, nr_: usize) {
-        kernel_masked_4x4(k, alpha, a, b, beta, c, rsc, csc, mr_, nr_)
-    }
 }
 
 /// 4x4 matrix multiplication kernel for f32
@@ -88,27 +76,6 @@ pub unsafe fn kernel_4x4(k: usize, alpha: T, a: *const T, b: *const T,
         loop4x4!(i, j, *c![i, j] = alpha * ab[i][j]);
     } else {
         loop4x4!(i, j, *c![i, j] = *c![i, j] * beta + alpha * ab[i][j]);
-    }
-}
-
-#[inline(never)]
-pub unsafe fn kernel_masked_4x4(k: usize, alpha: T, a: *const T, b: *const T,
-                                beta: T, c: *mut T, rsc: isize, csc: isize,
-                                rows: usize, cols: usize)
-{
-    let mut ab = [[0.; 4]; 4];
-    kernel_4x4(k, 1., a, b, 0., &mut ab[0][0], 4, 1);
-    for i in 0..rows {
-        for j in 0..cols {
-            if i >= 4 || j >= 4 { break; }
-            let cptr = c.offset(rsc * i as isize + csc * j as isize);
-            if beta == 0. {
-                *cptr = 0.; // initialize C
-            } else {
-                *cptr *= beta;
-            }
-            *cptr += alpha * ab[i][j];
-        }
     }
 }
 

--- a/tests/sgemm.rs
+++ b/tests/sgemm.rs
@@ -122,6 +122,7 @@ fn test_mul_with_id<F>(m: usize, n: usize, small: bool)
     let mut a = vec![F::zero(); m * k]; 
     let mut b = vec![F::zero(); k * n];
     let mut c = vec![F::zero(); m * n];
+    println!("test matrix with id input M={}, N={}", m, n);
 
     for (i, elt) in a.iter_mut().enumerate() {
         *elt = F::from(i as i64);


### PR DESCRIPTION
- Add an element trait to access the one, zero elements of f32, f64 and so on.
- Then break out the masked kernel logic to make it a general implementation

(However we cheat, to use an array on the stack for now, with the correct size. Can be fixed when
we get more than 4x4 kernels. I did check that the complied code is the same when using a vector there as an array.)

- I noticed that masked_kernel had its own codegen of the gemm kernel, and that it produced better code! It was using wide AVX registers (ymm1, ymm2 etc) instead of just the xmm1 registers. I don't really understand why this happens. So.. if I change all kernel use to go through masked_kernel, performance improves!
-  First difference is that masked_kernel writes into a local buffer, with known row/col stride. After that it copies from the buffer to C, the destination.
- Second difference is that the kernel is then always called with fixed α=1, β=0.
- Third difference is that masked_kernel is `inline(never)`. This seems to be important.

Summary of improvements! With this, we halve the distance to OpenBLAS's [f32 benchmark](http://bluss.github.io/rust/2016/03/28/a-gemmed-rabbit-hole/)

```
name                        before ns/iter  after ns/iter    diff ns/iter   diff %
mat_mul_f32::m127           290,740         208,380               -82,360  -28.33%
mat_mul_f32::mix10000       23,430,259      16,291,680         -7,138,579  -30.47%
mat_mul_f64::m127           433,429         343,568               -89,861  -20.73%
mat_mul_f64::mix10000       36,255,323      27,606,065         -8,649,258  -23.86%
nonative_mat_mul_f32::m127  375,725         291,936               -83,789  -22.30%
nonative_mat_mul_f64::m127  503,924         478,248               -25,676   -5.10%
```