### PR TITLE
Non-square µ-kernels, aligned buffers and a 8-by-4 kernel for dgemm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ script:
       travis-cargo build &&
       travis-cargo test &&
       travis-cargo test -- --release &&
-      travis-cargo test &&
       travis-cargo bench -- --no-run &&
       travis-cargo doc
 after_success:

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -17,12 +17,15 @@ impl GemmKernel for Gemm {
     type Elem = T;
 
     #[inline(always)]
+    fn align_to() -> usize { 0 }
+
+    #[inline(always)]
     fn mr() -> usize { 4 }
     #[inline(always)]
     fn nr() -> usize { 4 }
 
     #[inline(always)]
-    fn align_to() -> usize { 0 }
+    fn always_masked() -> bool { true }
 
     #[inline(always)]
     fn nc() -> usize { archparam::D_NC }

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -167,13 +167,13 @@ unsafe fn gemm_packed<K>(nc: usize, kc: usize, mc: usize,
     // LOOP 2: through micropanels in packed `b`
     for (l2, nr_) in range_chunk(nc, nr) {
         dprint!("LOOP 2, {}, nr_={}", l2, nr_);
-        let bpp = bpp.stride_offset(kc as isize, nr * l2);
+        let bpp = bpp.stride_offset(1, kc * nr * l2);
         let c = c.stride_offset(csc, nr * l2);
 
         // LOOP 1: through micropanels in packed `a` while `b` is constant
         for (l1, mr_) in range_chunk(mc, mr) {
             dprint!("LOOP 1, {}, mr_={}", l1, mr_);
-            let app = app.stride_offset(kc as isize, mr * l1);
+            let app = app.stride_offset(1, kc * mr * l1);
             let c = c.stride_offset(rsc, mr * l1);
 
             // GEMM KERNEL

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -294,10 +294,11 @@ unsafe fn masked_kernel<T, K>(k: usize, alpha: T,
 {
     let mr = K::mr();
     let nr = K::nr();
-    K::kernel(k, T::one(), a, b, T::zero(), mask_buf, mr as isize , 1);
+    // use column major order for `mask_buf`
+    K::kernel(k, T::one(), a, b, T::zero(), mask_buf, 1, mr as isize);
     let mut ab = mask_buf;
-    for i in 0..mr {
-        for j in 0..nr {
+    for j in 0..nr {
+        for i in 0..mr {
             if i < rows && j < cols {
                 let cptr = c.offset(rsc * i as isize + csc * j as isize);
                 if beta.is_zero() {

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -20,6 +20,11 @@ pub trait GemmKernel {
     /// Kernel cols
     fn nr() -> usize;
 
+    /// Whether to always use the masked wrapper around the kernel.
+    ///
+    /// If masked, the kernel is always called with α=1, β=0
+    fn always_masked() -> bool;
+
     fn nc() -> usize;
     fn kc() -> usize;
     fn mc() -> usize;

--- a/src/loopmacros.rs
+++ b/src/loopmacros.rs
@@ -15,9 +15,40 @@ macro_rules! loop4 {
     }}
 }
 
+macro_rules! loop8 {
+    ($i:ident, $e:expr) => {{
+        let $i = 0; $e;
+        let $i = 1; $e;
+        let $i = 2; $e;
+        let $i = 3; $e;
+        let $i = 4; $e;
+        let $i = 5; $e;
+        let $i = 6; $e;
+        let $i = 7; $e;
+    }}
+}
+
 macro_rules! loop4x4 {
     ($i:ident, $j:ident, $e:expr) => {{
         loop4!($i, loop4!($j, $e));
+    }}
+}
+
+macro_rules! loop8x4 {
+    ($i:ident, $j:ident, $e:expr) => {{
+        loop8!($i, loop4!($j, $e));
+    }}
+}
+
+macro_rules! unroll_by_4 {
+    ($ntimes:expr, $e:expr) => {{
+        let k = $ntimes;
+        for _ in 0..k / 4 {
+            $e;$e; $e;$e;
+        }
+        for _ in 0..k % 4 {
+            $e
+        }
     }}
 }
 

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -17,12 +17,15 @@ impl GemmKernel for Gemm {
     type Elem = T;
 
     #[inline(always)]
+    fn align_to() -> usize { 0 }
+
+    #[inline(always)]
     fn mr() -> usize { 4 }
     #[inline(always)]
     fn nr() -> usize { 4 }
 
     #[inline(always)]
-    fn align_to() -> usize { 0 }
+    fn always_masked() -> bool { true }
 
     #[inline(always)]
     fn nc() -> usize { archparam::S_NC }


### PR DESCRIPTION
Support aligned buffers in preparation for plugging in better vectorized solutions that need it.

It turns out dgemm improves with a 8-by-4 µ-kernel (instead of 4-by-4) when AVX is available, so we use it.

Benchmark report says it improves throughput up to 18% with -target-cpu=native with AVX, but regresses by 16% by with default release mode settings on the same platform. We will choose to merge this to shoot for the best possible performance.

```
name                           4x4-dgemm.log ns/iter  8x4-dgemm.log ns/iter    diff ns/iter   diff %
mat_mul_f64::m016              1,254                  1,103                            -151  -12.04%
mat_mul_f64::m064              47,573                 38,887                         -8,686  -18.26%
mat_mul_f64::m127              344,298                279,235                       -65,063  -18.90%
mat_mul_f64::mix128x10000x128  27,606,065             22,934,117                 -4,671,948  -16.92%
nonative_mat_mul_f64::m127     473,111                549,677                        76,566   16.18%
```

I did some simplifications to the rust µ-kernels as suggested by @vbarrielle. The kernel mask buffer is on the stack, manually aligned (would be nice with some support for using const fn + array sizes here); the mask buffer must be outside the masked_kernel function to keep the codegen this good.