### PR TITLE
Use a 4-by-8 microkernel for sgemm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["bluss"]
 license = "MIT/Apache-2.0"
 
 repository = "https://github.com/bluss/matrixmultiply/"
-documentation = "http://bluss.github.io/matrixmultiply/"
+documentation = "https://bluss.github.io/matrixmultiply/"
 
 description = "General matrix multiplication of f32 and f64 matrices in Rust. Supports matrices with general strides. Uses a microkernel strategy, so that the implementation is easy to parallelize and optimize. `RUSTFLAGS=\"-C target-cpu=native\"` is your friend here."
 

--- a/README.rst
+++ b/README.rst
@@ -15,14 +15,14 @@ multithreading).
 
 Please read the `API documentation here`__
 
-__ http://bluss.github.io/matrixmultiply/
+__ https://bluss.github.io/matrixmultiply/
 
 |build_status|_ |crates|_
 
 .. |build_status| image:: https://travis-ci.org/bluss/matrixmultiply.svg?branch=master
 .. _build_status: https://travis-ci.org/bluss/matrixmultiply
 
-.. |crates| image:: http://meritbadge.herokuapp.com/matrixmultiply
+.. |crates| image:: https://meritbadge.herokuapp.com/matrixmultiply
 .. _crates: https://crates.io/crates/matrixmultiply
 
 **NOTE: Compile this crate using** ``RUSTFLAGS="-C target-cpu=native"`` **so

--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -97,8 +97,11 @@ macro_rules! mat_mul {
 
 mat_mul!{mat_mul_f32, sgemm,
     (m004, 4, 4, 4)
+    (m005, 5, 5, 5)
+    (m006, 6, 6, 6)
     (m007, 7, 7, 7)
     (m008, 8, 8, 8)
+    (m009, 9, 9, 9)
     (m012, 12, 12, 12)
     (m016, 16, 16, 16)
     (m032, 32, 32, 32)
@@ -127,4 +130,66 @@ mat_mul!{mat_mul_f64, dgemm,
     (mix32x2, 32, 2, 32)
     (mix97, 97, 97, 125)
     (mix128x10000x128, 128, 10000, 128)
+}
+
+use std::ops::{Add, Mul};
+
+trait Z {
+    fn zero() -> Self;
+}
+impl Z for f32 { fn zero() -> Self { 0. } }
+impl Z for f64 { fn zero() -> Self { 0. } }
+
+// simple, slow, correct (hopefully) mat mul (Row Major)
+#[inline(never)]
+fn reference_mat_mul<A>(m: usize, k: usize, n: usize, a: &[A], b: &[A], c: &mut [A])
+    where A: Z + Add<Output=A> + Mul<Output=A> + Copy,
+{
+    assert!(a.len() >= m * k);
+    assert!(b.len() >= k * n);
+    assert!(c.len() >= m * n);
+
+    for i in 0..m {
+        for j in 0..k {
+            unsafe {
+                let celt = c.get_unchecked_mut(i * m + j);
+                *celt = (0..k).fold(A::zero(),
+                    move |s, x| s + *a.get_unchecked(i * k + x) * *b.get_unchecked(x * n + j));
+            }
+        }
+    }
+}
+
+macro_rules! ref_mat_mul {
+    ($modname:ident, $ty:ty, $(($name:ident, $m:expr, $n:expr, $k:expr))+) => {
+        mod $modname {
+            use test::{Bencher};
+            use super::reference_mat_mul;
+            $(
+            #[bench]
+            fn $name(bench: &mut Bencher)
+            {
+                let a = vec![0. as $ty; $m * $n]; 
+                let b = vec![0.; $n * $k];
+                let mut c = vec![0.; $m * $k];
+                bench.iter(|| {
+                    reference_mat_mul($m, $n, $k, &a, &b, &mut c);
+                    c[0]
+                });
+            }
+            )+
+        }
+    };
+}
+ref_mat_mul!{ref_mat_mul_f32, f32,
+    (m004, 4, 4, 4)
+    (m005, 5, 5, 5)
+    (m006, 6, 6, 6)
+    (m007, 7, 7, 7)
+    (m008, 8, 8, 8)
+    (m009, 9, 9, 9)
+    (m012, 12, 12, 12)
+    (m016, 16, 16, 16)
+    (m032, 32, 32, 32)
+    (m064, 64, 64, 64)
 }

--- a/docs/sgemm4x4.log
+++ b/docs/sgemm4x4.log
@@ -1,0 +1,12 @@
+
+test mat_mul_f32::m004             ... bench:         153 ns/iter (+/- 2)
+test mat_mul_f32::m007             ... bench:         280 ns/iter (+/- 7)
+test mat_mul_f32::m008             ... bench:         305 ns/iter (+/- 4)
+test mat_mul_f32::m012             ... bench:         598 ns/iter (+/- 18)
+test mat_mul_f32::m016             ... bench:       1,044 ns/iter (+/- 131)
+test mat_mul_f32::m032             ... bench:       5,037 ns/iter (+/- 76)
+test mat_mul_f32::m064             ... bench:      30,305 ns/iter (+/- 1,550)
+
+test mat_mul_f32::m127             ... bench:     208,380 ns/iter (+/- 3,311)
+test nonative_mat_mul_f32::m127             ... bench:     291,936 ns/iter (+/- 10,408)
+test mat_mul_f32::mix128x10000x128 ... bench:  16,291,680 ns/iter (+/- 1,350,524)

--- a/docs/sgemm4x8.log
+++ b/docs/sgemm4x8.log
@@ -1,0 +1,11 @@
+
+test mat_mul_f32::m004             ... bench:         172 ns/iter (+/- 2)
+test mat_mul_f32::m007             ... bench:         271 ns/iter (+/- 5)
+test mat_mul_f32::m008             ... bench:         286 ns/iter (+/- 15)
+test mat_mul_f32::m012             ... bench:         650 ns/iter (+/- 12)
+test mat_mul_f32::m016             ... bench:         945 ns/iter (+/- 59)
+test mat_mul_f32::m032             ... bench:       4,638 ns/iter (+/- 104)
+test mat_mul_f32::m064             ... bench:      27,748 ns/iter (+/- 587)
+test mat_mul_f32::m127             ... bench:     188,977 ns/iter (+/- 8,601)
+test mat_mul_f32::mix128x10000x128 ... bench:  14,293,288 ns/iter (+/- 2,022,603)
+test nonative_mat_mul_f32::m127             ... bench:     272,487 ns/iter (+/- 5,289)

--- a/src/loopmacros.rs
+++ b/src/loopmacros.rs
@@ -28,12 +28,6 @@ macro_rules! loop8 {
     }}
 }
 
-macro_rules! loop4x4 {
-    ($i:ident, $j:ident, $e:expr) => {{
-        loop4!($i, loop4!($j, $e));
-    }}
-}
-
 macro_rules! loop8x4 {
     ($i:ident, $j:ident, $e:expr) => {{
         loop8!($i, loop4!($j, $e));

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -49,7 +49,7 @@ impl GemmKernel for Gemm {
     }
 }
 
-/// 4x4 matrix multiplication kernel for f32
+/// matrix multiplication kernel
 ///
 /// This does the matrix multiplication:
 ///
@@ -60,7 +60,7 @@ impl GemmKernel for Gemm {
 /// + c has general strides
 /// + rsc: row stride of c
 /// + csc: col stride of c
-/// + if `beta` is 0, then c does not need to be initialized
+/// + if beta is 0, then c does not need to be initialized
 #[inline(always)]
 pub unsafe fn kernel(k: usize, alpha: T, a: *const T, b: *const T,
                      beta: T, c: *mut T, rsc: isize, csc: isize)

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -13,6 +13,9 @@ pub enum Gemm { }
 
 pub type T = f32;
 
+const MR: usize = 4;
+const NR: usize = 8;
+
 impl GemmKernel for Gemm {
     type Elem = T;
 
@@ -20,9 +23,9 @@ impl GemmKernel for Gemm {
     fn align_to() -> usize { 0 }
 
     #[inline(always)]
-    fn mr() -> usize { 4 }
+    fn mr() -> usize { MR }
     #[inline(always)]
-    fn nr() -> usize { 4 }
+    fn nr() -> usize { NR }
 
     #[inline(always)]
     fn always_masked() -> bool { true }
@@ -42,7 +45,7 @@ impl GemmKernel for Gemm {
         b: *const T,
         beta: T,
         c: *mut T, rsc: isize, csc: isize) {
-        kernel_4x4(k, alpha, a, b, beta, c, rsc, csc)
+        kernel(k, alpha, a, b, beta, c, rsc, csc)
     }
 }
 
@@ -59,22 +62,23 @@ impl GemmKernel for Gemm {
 /// + csc: col stride of c
 /// + if `beta` is 0, then c does not need to be initialized
 #[inline(always)]
-pub unsafe fn kernel_4x4(k: usize, alpha: T, a: *const T, b: *const T,
-                         beta: T, c: *mut T, rsc: isize, csc: isize)
+pub unsafe fn kernel(k: usize, alpha: T, a: *const T, b: *const T,
+                     beta: T, c: *mut T, rsc: isize, csc: isize)
 {
-    let mut ab = [[0.; 4]; 4];
+    let mut ab = [[0.; NR]; MR];
     let mut a = a;
     let mut b = b;
     debug_assert_eq!(beta, 0.); // always masked
 
     // Compute matrix multiplication into ab[i][j]
     unroll_by_8!(k, {
-        let v0 = [at(a, 0), at(a, 1), at(a, 2), at(a, 3)];
-        let v1 = [at(b, 0), at(b, 1), at(b, 2), at(b, 3)];
-        loop4x4!(i, j, ab[i][j] += v0[i] * v1[j]);
+        let v0: [_; MR] = [at(a, 0), at(a, 1), at(a, 2), at(a, 3)];
+        let v1: [_; NR] = [at(b, 0), at(b, 1), at(b, 2), at(b, 3),
+                           at(b, 4), at(b, 5), at(b, 6), at(b, 7)];
+        loop4!(i, loop8!(j, ab[i][j] += v0[i] * v1[j]));
 
-        a = a.offset(4);
-        b = b.offset(4);
+        a = a.offset(MR as isize);
+        b = b.offset(NR as isize);
     });
 
     macro_rules! c {
@@ -82,7 +86,9 @@ pub unsafe fn kernel_4x4(k: usize, alpha: T, a: *const T, b: *const T,
     }
 
     // set C = α A B
-    loop4x4!(i, j, *c![i, j] = alpha * ab[i][j]);
+    for j in 0..NR {
+        loop4!(i, *c![i, j] = alpha * ab[i][j]);
+    }
 }
 
 #[inline(always)]
@@ -93,18 +99,18 @@ unsafe fn at(ptr: *const T, i: usize) -> T {
 #[test]
 fn test_gemm_kernel() {
     let mut a = [1.; 16];
-    let mut b = [0.; 16];
+    let mut b = [0.; 32];
     for (i, x) in a.iter_mut().enumerate() {
         *x = i as f32;
     }
+
     for i in 0..4 {
-        b[i + i * 4] = 1.;
+        b[i + i * 8] = 1.;
     }
     let mut c = [0.; 16];
     unsafe {
-        kernel_4x4(4, 1., &a[0], &b[0],
-                   0., &mut c[0], 1, 4);
-        // transposed C so that results line up
+        kernel(4, 1., &a[0], &b[0], 0., &mut c[0], 1, 4);
+        // col major C
     }
     assert_eq!(&a, &c);
 }


### PR DESCRIPTION
Use a 4-by-8 microkernel for sgemm

Processing more data per kernel is a win. Some small sizes that need
more zero padding regress by a few percent.

```
name                           sgemm4x4.log ns/iter  sgemm4x8.log ns/iter    diff ns/iter   diff %
mat_mul_f32::m004              153                   172                               19   12.42%
mat_mul_f32::m007              280                   271                               -9   -3.21%
mat_mul_f32::m008              305                   286                              -19   -6.23%
mat_mul_f32::m012              598                   650                               52    8.70%
mat_mul_f32::m016              1,044                 945                              -99   -9.48%
mat_mul_f32::m032              5,037                 4,638                           -399   -7.92%
mat_mul_f32::m064              30,305                27,748                        -2,557   -8.44%
mat_mul_f32::m127              208,380               188,977                      -19,403   -9.31%
mat_mul_f32::mix128x10000x128  16,291,680            14,293,288                -1,998,392  -12.27%
nonative_mat_mul_f32::m127     291,936               272,487                      -19,449   -6.66%
```