### PR TITLE
Use mem::zeroed to fill the gemm kernel's array for the vectors

### DIFF
--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -65,7 +65,8 @@ impl GemmKernel for Gemm {
 pub unsafe fn kernel(k: usize, alpha: T, a: *const T, b: *const T,
                      beta: T, c: *mut T, rsc: isize, csc: isize)
 {
-    let mut ab = [[0.; NR]; MR];
+    // using `zeroed` is a workaround for issue https://github.com/bluss/matrixmultiply/issues/9
+    let mut ab: [[T; NR]; MR] = ::std::mem::zeroed();
     let mut a = a;
     let mut b = b;
     debug_assert_eq!(beta, 0.); // always masked

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -65,7 +65,8 @@ impl GemmKernel for Gemm {
 pub unsafe fn kernel(k: usize, alpha: T, a: *const T, b: *const T,
                      beta: T, c: *mut T, rsc: isize, csc: isize)
 {
-    let mut ab = [[0.; NR]; MR];
+    // using `zeroed` is a workaround for issue https://github.com/bluss/matrixmultiply/issues/9
+    let mut ab: [[T; NR]; MR] = ::std::mem::zeroed();
     let mut a = a;
     let mut b = b;
     debug_assert_eq!(beta, 0.); // always masked


### PR DESCRIPTION
This works around the performance regression on nightly (LLVM 3.9 + MIR trans), which was related to the failing removal of array initialization expressions like `[0.; 4]`. Using `zeroed` works arounds this. (Thank you @eddyb!)

Fixes #9 (by working around it)