### PR TITLE
Improve unrolling in sgemm kernel

### DIFF
--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -65,11 +65,12 @@ impl GemmKernel for Gemm {
 pub unsafe fn kernel(k: usize, alpha: T, a: *const T, b: *const T,
                      beta: T, c: *mut T, rsc: isize, csc: isize)
 {
-    // using `zeroed` is a workaround for issue https://github.com/bluss/matrixmultiply/issues/9
-    let mut ab: [[T; NR]; MR] = ::std::mem::zeroed();
+    // using `uninitialized` is a workaround for issue https://github.com/bluss/matrixmultiply/issues/9
+    let mut ab: [[T; NR]; MR] = ::std::mem::uninitialized();
     let mut a = a;
     let mut b = b;
     debug_assert_eq!(beta, 0.); // always masked
+    loop8!(i, loop4!(j, ab[i][j] = 0.));
 
     // Compute matrix multiplication into ab[i][j]
     unroll_by_4!(k, {

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -73,7 +73,7 @@ pub unsafe fn kernel(k: usize, alpha: T, a: *const T, b: *const T,
     loop8!(i, loop4!(j, ab[i][j] = 0.));
 
     // Compute matrix multiplication into ab[i][j]
-    unroll_by_4!(k, {
+    unroll_by!(4 => k, {
         let v0: [_; MR] = [at(a, 0), at(a, 1), at(a, 2), at(a, 3),
                            at(a, 4), at(a, 5), at(a, 6), at(a, 7)];
         let v1: [_; NR] = [at(b, 0), at(b, 1), at(b, 2), at(b, 3)];

--- a/src/loopmacros.rs
+++ b/src/loopmacros.rs
@@ -9,6 +9,17 @@
 
 // Unroll only in non-debug builds
 
+macro_rules! repeat {
+    (1 $e:expr) => { $e; };
+    (2 $e:expr) => { $e;$e; };
+    (3 $e:expr) => { $e;$e; $e; };
+    (4 $e:expr) => { $e;$e; $e;$e; };
+    (5 $e:expr) => { $e;$e; $e;$e; $e; };
+    (6 $e:expr) => { $e;$e; $e;$e; $e;$e; };
+    (7 $e:expr) => { $e;$e; $e;$e; $e;$e; $e; };
+    (8 $e:expr) => { $e;$e; $e;$e; $e;$e; $e;$e; };
+}
+
 macro_rules! loop4 {
     ($i:ident, $e:expr) => {{
         let $i = 0; $e;
@@ -40,41 +51,20 @@ macro_rules! loop8 {
 }
 
 #[cfg(debug_assertions)]
-macro_rules! unroll_by_4 {
-    ($ntimes:expr, $e:expr) => {
+macro_rules! unroll_by {
+    ($by:tt => $ntimes:expr, $e:expr) => {
         for _ in 0..$ntimes { $e }
     }
 }
 
 #[cfg(not(debug_assertions))]
-macro_rules! unroll_by_4 {
-    ($ntimes:expr, $e:expr) => {{
+macro_rules! unroll_by {
+    ($by:tt => $ntimes:expr, $e:expr) => {{
         let k = $ntimes;
-        for _ in 0..k / 4 {
-            $e;$e; $e;$e;
+        for _ in 0..k / $by {
+            repeat!($by $e);
         }
-        for _ in 0..k % 4 {
-            $e
-        }
-    }}
-}
-
-#[cfg(debug_assertions)]
-macro_rules! unroll_by_8 {
-    ($ntimes:expr, $e:expr) => {
-        for _ in 0..$ntimes { $e }
-    }
-}
-
-#[cfg(not(debug_assertions))]
-macro_rules! unroll_by_8 {
-    ($ntimes:expr, $e:expr) => {{
-        let k = $ntimes;
-        for _ in 0..k / 8 {
-            $e;$e; $e;$e;
-            $e;$e; $e;$e;
-        }
-        for _ in 0..k % 8 {
+        for _ in 0..k % $by {
             $e
         }
     }}

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -65,11 +65,12 @@ impl GemmKernel for Gemm {
 pub unsafe fn kernel(k: usize, alpha: T, a: *const T, b: *const T,
                      beta: T, c: *mut T, rsc: isize, csc: isize)
 {
-    // using `zeroed` is a workaround for issue https://github.com/bluss/matrixmultiply/issues/9
-    let mut ab: [[T; NR]; MR] = ::std::mem::zeroed();
+    // using `uninitialized` is a workaround for issue https://github.com/bluss/matrixmultiply/issues/9
+    let mut ab: [[T; NR]; MR] = ::std::mem::uninitialized();
     let mut a = a;
     let mut b = b;
     debug_assert_eq!(beta, 0.); // always masked
+    loop4!(i, loop8!(j, ab[i][j] = 0.));
 
     // Compute matrix multiplication into ab[i][j]
     unroll_by_4!(k, {

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -107,11 +107,11 @@ fn test_gemm_kernel() {
     for i in 0..4 {
         b[i + i * 8] = 1.;
     }
-    let mut c = [0.; 16];
+    let mut c = [0.; 32];
     unsafe {
         kernel(4, 1., &a[0], &b[0], 0., &mut c[0], 1, 4);
         // col major C
     }
-    assert_eq!(&a, &c);
+    assert_eq!(&a, &c[..16]);
 }
 

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -73,7 +73,7 @@ pub unsafe fn kernel(k: usize, alpha: T, a: *const T, b: *const T,
     loop4!(i, loop8!(j, ab[i][j] = 0.));
 
     // Compute matrix multiplication into ab[i][j]
-    unroll_by_4!(k, {
+    unroll_by!(5 => k, {
         let v0: [_; MR] = [at(a, 0), at(a, 1), at(a, 2), at(a, 3)];
         let v1: [_; NR] = [at(b, 0), at(b, 1), at(b, 2), at(b, 3),
                            at(b, 4), at(b, 5), at(b, 6), at(b, 7)];

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -72,7 +72,7 @@ pub unsafe fn kernel(k: usize, alpha: T, a: *const T, b: *const T,
     debug_assert_eq!(beta, 0.); // always masked
 
     // Compute matrix multiplication into ab[i][j]
-    unroll_by_8!(k, {
+    unroll_by_4!(k, {
         let v0: [_; MR] = [at(a, 0), at(a, 1), at(a, 2), at(a, 3)];
         let v1: [_; NR] = [at(b, 0), at(b, 1), at(b, 2), at(b, 3),
                            at(b, 4), at(b, 5), at(b, 6), at(b, 7)];
@@ -87,9 +87,7 @@ pub unsafe fn kernel(k: usize, alpha: T, a: *const T, b: *const T,
     }
 
     // set C = α A B
-    for j in 0..NR {
-        loop4!(i, *c![i, j] = alpha * ab[i][j]);
-    }
+    loop8!(j, loop4!(i, *c![i, j] = alpha * ab[i][j]));
 }
 
 #[inline(always)]


### PR DESCRIPTION
-C target-cpu=native
```
name               sgemm-4x8-before.log ns/iter  sgemm-4x8-unroll5.log ns/iter    diff ns/iter   diff %
mat_mul_f32::m004  132                           109                                       -23  -17.42%
mat_mul_f32::m005  205                           151                                       -54  -26.34%
mat_mul_f32::m006  229                           166                                       -63  -27.51%
mat_mul_f32::m007  250                           182                                       -68  -27.20%
mat_mul_f32::m008  219                           200                                       -19   -8.68%
mat_mul_f32::m009  465                           377                                       -88  -18.92%
mat_mul_f32::m012  628                           454                                      -174  -27.71%
mat_mul_f32::m016  826                           706                                      -120  -14.53%
mat_mul_f32::m032  4,326                         3,459                                    -867  -20.04%
mat_mul_f32::m064  26,965                        20,754                                 -6,211  -23.03%
mat_mul_f32::m127  198,835                       139,403                               -59,432  -29.89%
mat_mul_f32::m256  1,383,352                     995,665                              -387,687  -28.03%
```

default codegen (without native) seems to be some gains and some losses. Potentially a bit noisy:

```
mat_mul_f32::m004  139                     118                                -21  -15.11%
mat_mul_f32::m005  235                     169                                -66  -28.09%
mat_mul_f32::m006  249                     193                                -56  -22.49%
mat_mul_f32::m007  279                     202                                -77  -27.60%
mat_mul_f32::m008  218                     218                                  0    0.00%
mat_mul_f32::m009  463                     404                                -59  -12.74%
mat_mul_f32::m012  676                     535                               -141  -20.86%
mat_mul_f32::m016  868                     818                                -50   -5.76%
mat_mul_f32::m032  4,346                   4,457                              111    2.55%
mat_mul_f32::m064  27,170                  28,644                           1,474    5.43%
mat_mul_f32::m127  208,203                 199,995                         -8,208   -3.94%
mat_mul_f32::m256  1,405,806               1,504,363                       98,557    7.01%
```