### PR TITLE
Use CARGO_CFG_TARGET_FEATURE to pick sgemm 8x8 if avx exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,30 +3,20 @@ sudo: false
 
 # run builds for all the trains (and more)
 rust:
+  - 1.12.0
   - stable
   - beta
   - nightly
 
-# load travis-cargo
-before_script:
-  - |
-      pip install 'travis-cargo<0.2' --user &&
-      export PATH=$HOME/.local/bin:$PATH
-
 # the main build
 script:
   - |
-      travis-cargo build &&
-      travis-cargo test &&
-      travis-cargo test -- --release &&
-      travis-cargo doc &&
+      cargo build &&
+      cargo test &&
+      cargo test --release &&
+      cargo doc &&
       cargo bench
 
 branches:
   only:
     - master
-
-env:
-  global:
-    # override the default `--features unstable` used for the nightly branch (optional)
-    - TRAVIS_CARGO_NIGHTLY_FEATURE=""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ description = "General matrix multiplication of f32 and f64 matrices in Rust. Su
 
 keywords = ["matrix", "sgemm", "dgemm"]
 
+build = "build.rs"
+
 [lib]
 bench = false
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,14 @@
+
+//!
+
+use std::env;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    if let Ok(features) = env::var("CARGO_CFG_TARGET_FEATURE") {
+        if features.split(",").map(|s| s.trim()).any(|feat| feat == "avx") {
+            println!("cargo:rustc-cfg=sgemm_8x8");
+        }
+    }
+}

--- a/src/loopmacros.rs
+++ b/src/loopmacros.rs
@@ -6,6 +6,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+macro_rules! if_cfg {
+    ($id:ident, $type_:ty, $x:expr, $y:expr) => {{
+        #[cfg($id)]
+        const TMP: $type_ = $x;
+        #[cfg(not($id))]
+        const TMP: $type_ = $y;
+        TMP
+    }}
+}
 
 // Unroll only in non-debug builds
 

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -13,15 +13,15 @@ pub enum Gemm { }
 
 pub type T = f32;
 
-const MR: usize = 4;
+const MR: usize = if_cfg!(sgemm_8x8, usize, 8, 4);
 const NR: usize = 8;
 
-macro_rules! loop_m {
-    ($i:ident, $e:expr) => { loop4!($i, $e) };
-}
-macro_rules! loop_n {
-    ($j:ident, $e:expr) => { loop8!($j, $e) };
-}
+#[cfg(sgemm_8x8)]
+macro_rules! loop_m { ($i:ident, $e:expr) => { loop8!($i, $e) }; }
+#[cfg(not(sgemm_8x8))]
+macro_rules! loop_m { ($i:ident, $e:expr) => { loop4!($i, $e) }; }
+
+macro_rules! loop_n { ($j:ident, $e:expr) => { loop8!($j, $e) }; }
 
 impl GemmKernel for Gemm {
     type Elem = T;


### PR DESCRIPTION
In sgemm (f32) use 8x8 kernel if AVX is enabled. (This is open to more platform specific tuning).

Improvement from sgemm 4x8 to 8x8 with avx:
```
 name                     old-f32 ns/iter  new-f32 ns/iter  diff ns/iter   diff % 
 mat_mul_f32::m004        110              103                        -7   -6.36% 
 mat_mul_f32::m005        162              117                       -45  -27.78% 
 mat_mul_f32::m006        170              136                       -34  -20.00% 
 mat_mul_f32::m007        191              148                       -43  -22.51% 
 mat_mul_f32::m008        211              163                       -48  -22.75% 
 mat_mul_f32::m009        371              346                       -25   -6.74% 
 mat_mul_f32::m012        484              461                       -23   -4.75% 
 mat_mul_f32::m016        702              605                       -97  -13.82% 
 mat_mul_f32::m032        3,513            3,013                    -500  -14.23% 
 mat_mul_f32::m064        20,804           18,757                 -2,047   -9.84% 
 mat_mul_f32::m127        143,522          124,790               -18,732  -13.05% 
 mat_mul_f32::m256        1,029,880        904,001              -125,879  -12.22% 
```