### PR TITLE
Relax debug assertion on strides of C matrix

### DIFF
--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -114,7 +114,8 @@ unsafe fn gemm_loop<K>(
     c: *mut K::Elem, rsc: isize, csc: isize)
     where K: GemmKernel
 {
-    debug_assert!(m * n == 0 || (rsc != 0 && csc != 0));
+    debug_assert!(m <= 1 || n == 0 || rsc != 0);
+    debug_assert!(m == 0 || n <= 1 || csc != 0);
     // if A or B have no elements, compute C ← βC and return
     if m == 0 || k == 0 || n == 0 {
         for i in 0..m {


### PR DESCRIPTION
A stride is irrelevant if the length of its axis is ≤ 1 or if the length of the other axis is 0, since its value is never used in an offset. (There may be an offset of `0 * stride` if the length of the axis is 1, but 0 times anything is zero, so the stride is irrelevant.)