### PR TITLE
Implement sgemm and dgemm using fma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
+os: linux
 language: rust
-sudo: false
+sudo: yes
+dist: trusty
 
 matrix:
   include:
@@ -22,6 +24,11 @@ matrix:
       env:
         TARGET=x86_64-unknown-linux-gnu
         MMNO_avx=1
+        MMNO_fma=1
+    - rust: nightly
+      env:
+        TARGET=x86_64-unknown-linux-gnu
+        MMNO_fma=1
     - rust: nightly
       env:
         TARGET=aarch64-unknown-linux-gnu

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -28,13 +28,18 @@ macro_rules! loop_n {
     ($j:ident, $e:expr) => { loop4!($j, $e) };
 }
 
+
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+struct KernelFma;
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+struct KernelAvx;
+
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
 trait DgemmMultiplyAdd {
     unsafe fn multiply_add(__m256d, __m256d, __m256d) -> __m256d;
 }
 
-struct KernelFma;
-struct KernelAvx;
-
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
 impl DgemmMultiplyAdd for KernelAvx {
     #[inline(always)]
     unsafe fn multiply_add(a: __m256d, b: __m256d, c: __m256d) -> __m256d {
@@ -42,6 +47,7 @@ impl DgemmMultiplyAdd for KernelAvx {
     }
 }
 
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
 impl DgemmMultiplyAdd for KernelFma {
     #[inline(always)]
     unsafe fn multiply_add(a: __m256d, b: __m256d, c: __m256d) -> __m256d {

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -77,7 +77,9 @@ pub unsafe fn kernel(k: usize, alpha: T, a: *const T, b: *const T,
     // dispatch to specific compiled versions
     #[cfg(any(target_arch="x86", target_arch="x86_64"))]
     {
-        if is_x86_feature_detected_!("avx") {
+        if is_x86_feature_detected_!("fma") {
+            return kernel_target_fma(k, alpha, a, b, beta, c, rsc, csc);
+        } else if is_x86_feature_detected_!("avx") {
             return kernel_target_avx(k, alpha, a, b, beta, c, rsc, csc);
         } else if is_x86_feature_detected_!("sse2") {
             return kernel_target_sse2(k, alpha, a, b, beta, c, rsc, csc);
@@ -93,6 +95,15 @@ unsafe fn kernel_target_avx(k: usize, alpha: T, a: *const T, b: *const T,
                             beta: T, c: *mut T, rsc: isize, csc: isize)
 {
     kernel_x86_avx(k, alpha, a, b, beta, c, rsc, csc)
+}
+
+#[inline]
+#[target_feature(enable="fma")]
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+unsafe fn kernel_target_fma(k: usize, alpha: T, a: *const T, b: *const T,
+                            beta: T, c: *mut T, rsc: isize, csc: isize)
+{
+    kernel_x86_fma(k, alpha, a, b, beta, c, rsc, csc)
 }
 
 #[inline]
@@ -304,8 +315,8 @@ unsafe fn kernel_x86_avx(k: usize, alpha: T, a: *const T, b: *const T,
 
     // C ← α A B + β C
     let mut cv = [_mm256_setzero_ps(); MR];
-    let betav = _mm256_set1_ps(beta);
     if beta != 0. {
+        let betav = _mm256_set1_ps(beta);
         // Read C
         if csc == 1 {
             loop_m!(i, cv[i] = _mm256_loadu_ps(c![i, 0]));
@@ -319,6 +330,247 @@ unsafe fn kernel_x86_avx(k: usize, alpha: T, a: *const T, b: *const T,
 
     // Compute (α A B) + (β C)
     loop_m!(i, cv[i] = _mm256_add_ps(cv[i], ab[i]));
+
+    // Store C back to memory
+    if csc == 1 {
+        loop_m!(i, _mm256_storeu_ps(c![i, 0], cv[i]));
+    } else {
+        // Permute to bring each element in the vector to the front and store
+        loop_m!(i, {
+            let cvlo = _mm256_extractf128_ps(cv[i], 0);
+            let cvhi = _mm256_extractf128_ps(cv[i], 1);
+
+            _mm_store_ss(c![i, 0], cvlo);
+            let cperm = _mm_permute_ps(cvlo, permute_mask!(0, 3, 2, 1));
+            _mm_store_ss(c![i, 1], cperm);
+            let cperm = _mm_permute_ps(cperm, permute_mask!(0, 3, 2, 1));
+            _mm_store_ss(c![i, 2], cperm);
+            let cperm = _mm_permute_ps(cperm, permute_mask!(0, 3, 2, 1));
+            _mm_store_ss(c![i, 3], cperm);
+
+            _mm_store_ss(c![i, 4], cvhi);
+            let cperm = _mm_permute_ps(cvhi, permute_mask!(0, 3, 2, 1));
+            _mm_store_ss(c![i, 5], cperm);
+            let cperm = _mm_permute_ps(cperm, permute_mask!(0, 3, 2, 1));
+            _mm_store_ss(c![i, 6], cperm);
+            let cperm = _mm_permute_ps(cperm, permute_mask!(0, 3, 2, 1));
+            _mm_store_ss(c![i, 7], cperm);
+        });
+    }
+}
+
+#[inline(always)]
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+unsafe fn kernel_x86_fma(k: usize, alpha: T, a: *const T, b: *const T,
+                         beta: T, c: *mut T, rsc: isize, csc: isize)
+{
+    debug_assert_ne!(k, 0);
+
+    let mut ab = [_mm256_setzero_ps(); MR];
+
+    // this kernel can operate in either transposition (C = A B or C^T = B^T A^T)
+    let prefer_row_major_c = rsc != 1;
+
+    let (mut a, mut b) = if prefer_row_major_c { (a, b) } else { (b, a) };
+    let (rsc, csc) = if prefer_row_major_c { (rsc, csc) } else { (csc, rsc) };
+
+    macro_rules! shuffle_mask {
+        ($z:expr, $y:expr, $x:expr, $w:expr) => {
+            ($z << 6) | ($y << 4) | ($x << 2) | $w
+        }
+    }
+    macro_rules! permute_mask {
+        ($z:expr, $y:expr, $x:expr, $w:expr) => {
+            ($z << 6) | ($y << 4) | ($x << 2) | $w
+        }
+    }
+
+    macro_rules! permute2f128_mask {
+        ($y:expr, $x:expr) => {
+            (($y << 4) | $x)
+        }
+    }
+
+    // Start data load before each iteration
+    let mut av = _mm256_load_ps(a);
+    let mut bv = _mm256_load_ps(b);
+
+    // Compute A B
+    unroll_by_with_last!(4 => k, is_last, {
+        // We compute abij = ai bj
+        //
+        // Load b as one contiguous vector
+        // Load a as striped vectors
+        //
+        // Shuffle the abij elements in order after the loop.
+        //
+        // Note this scheme copied and transposed from the BLIS 8x8 sgemm
+        // microkernel.
+        //
+        // Our a indices are striped and our b indices are linear. In
+        // the variable names below, we always have doubled indices so
+        // for example a0246 corresponds to a vector of a0 a0 a2 a2 a4 a4 a6 a6.
+        //
+        // ab0246: ab2064: ab4602: ab6420:
+        // ( ab00  ( ab20  ( ab40  ( ab60
+        //   ab01    ab21    ab41    ab61
+        //   ab22    ab02    ab62    ab42
+        //   ab23    ab03    ab63    ab43
+        //   ab44    ab64    ab04    ab24
+        //   ab45    ab65    ab05    ab25
+        //   ab66    ab46    ab26    ab06
+        //   ab67 )  ab47 )  ab27 )  ab07 )
+        //
+        // ab1357: ab3175: ab5713: ab7531:
+        // ( ab10  ( ab30  ( ab50  ( ab70
+        //   ab11    ab31    ab51    ab71
+        //   ab32    ab12    ab72    ab52
+        //   ab33    ab13    ab73    ab53
+        //   ab54    ab74    ab14    ab34
+        //   ab55    ab75    ab15    ab35
+        //   ab76    ab56    ab36    ab16
+        //   ab77 )  ab57 )  ab37 )  ab17 )
+
+        const PERM32_2301: i32 = permute_mask!(1, 0, 3, 2);
+        const PERM128_30: i32 = permute2f128_mask!(0, 3);
+
+        // _mm256_moveldup_ps(av):
+        // vmovsldup ymm2, ymmword ptr [rax]
+        //
+        // Load and duplicate each even word:
+        // ymm2 ← [a0 a0 a2 a2 a4 a4 a6 a6]
+        //
+        // _mm256_movehdup_ps(av):
+        // vmovshdup ymm2, ymmword ptr [rax]
+        //
+        // Load and duplicate each odd word:
+        // ymm2 ← [a1 a1 a3 a3 a5 a5 a7 a7]
+        //
+
+        let a0246 = _mm256_moveldup_ps(av); // Load: a0 a0 a2 a2 a4 a4 a6 a6
+        let a2064 = _mm256_permute_ps(a0246, PERM32_2301);
+
+        let a1357 = _mm256_movehdup_ps(av); // Load: a1 a1 a3 a3 a5 a5 a7 a7
+        let a3175 = _mm256_permute_ps(a1357, PERM32_2301);
+
+        let a4602 = _mm256_permute2f128_ps(a0246, a0246, PERM128_30);
+        let a6420 = _mm256_permute2f128_ps(a2064, a2064, PERM128_30);
+
+        let a5713 = _mm256_permute2f128_ps(a1357, a1357, PERM128_30);
+        let a7531 = _mm256_permute2f128_ps(a3175, a3175, PERM128_30);
+
+        ab[0] = _mm256_fmadd_ps(a0246, bv, ab[0]);
+        ab[1] = _mm256_fmadd_ps(a2064, bv, ab[1]);
+        ab[2] = _mm256_fmadd_ps(a4602, bv, ab[2]);
+        ab[3] = _mm256_fmadd_ps(a6420, bv, ab[3]);
+
+        ab[4] = _mm256_fmadd_ps(a1357, bv, ab[4]);
+        ab[5] = _mm256_fmadd_ps(a3175, bv, ab[5]);
+        ab[6] = _mm256_fmadd_ps(a5713, bv, ab[6]);
+        ab[7] = _mm256_fmadd_ps(a7531, bv, ab[7]);
+
+        if !is_last {
+            a = a.add(MR);
+            b = b.add(NR);
+
+            bv = _mm256_load_ps(b);
+            av = _mm256_load_ps(a);
+        }
+    });
+
+    // Permute to put the abij elements in order
+    //
+    // shufps 0xe4: 22006644 00224466 -> 22226666
+    //
+    // vperm2 0x30: 00004444 44440000 -> 00000000
+    // vperm2 0x12: 00004444 44440000 -> 44444444
+    //
+
+    let ab0246 = ab[0];
+    let ab2064 = ab[1];
+    let ab4602 = ab[2];
+    let ab6420 = ab[3];
+
+    let ab1357 = ab[4];
+    let ab3175 = ab[5];
+    let ab5713 = ab[6];
+    let ab7531 = ab[7];
+
+    const SHUF_0123: i32 = shuffle_mask!(3, 2, 1, 0);
+    debug_assert_eq!(SHUF_0123, 0xE4);
+
+    const PERM128_03: i32 = permute2f128_mask!(3, 0);
+    const PERM128_21: i32 = permute2f128_mask!(1, 2);
+
+    // No elements are "shuffled" in truth, they all stay at their index
+    // but we combine vectors to de-stripe them.
+    //
+    // For example, the first shuffle below uses 0 1 2 3 which
+    // corresponds to the X0 X1 Y2 Y3 sequence etc:
+    //
+    //                                             variable
+    // X ab00 ab01 ab22 ab23 ab44 ab45 ab66 ab67   ab0246
+    // Y ab20 ab21 ab02 ab03 ab64 ab65 ab46 ab47   ab2064
+    // 
+    //   X0   X1   Y2   Y3   X4   X5   Y6   Y7
+    // = ab00 ab01 ab02 ab03 ab44 ab45 ab46 ab47   ab0044
+
+    let ab0044 = _mm256_shuffle_ps(ab0246, ab2064, SHUF_0123);
+    let ab2266 = _mm256_shuffle_ps(ab2064, ab0246, SHUF_0123);
+
+    let ab4400 = _mm256_shuffle_ps(ab4602, ab6420, SHUF_0123);
+    let ab6622 = _mm256_shuffle_ps(ab6420, ab4602, SHUF_0123);
+
+    let ab1155 = _mm256_shuffle_ps(ab1357, ab3175, SHUF_0123);
+    let ab3377 = _mm256_shuffle_ps(ab3175, ab1357, SHUF_0123);
+
+    let ab5511 = _mm256_shuffle_ps(ab5713, ab7531, SHUF_0123);
+    let ab7733 = _mm256_shuffle_ps(ab7531, ab5713, SHUF_0123);
+
+    let ab0000 = _mm256_permute2f128_ps(ab0044, ab4400, PERM128_03);
+    let ab4444 = _mm256_permute2f128_ps(ab0044, ab4400, PERM128_21);
+
+    let ab2222 = _mm256_permute2f128_ps(ab2266, ab6622, PERM128_03);
+    let ab6666 = _mm256_permute2f128_ps(ab2266, ab6622, PERM128_21);
+
+    let ab1111 = _mm256_permute2f128_ps(ab1155, ab5511, PERM128_03);
+    let ab5555 = _mm256_permute2f128_ps(ab1155, ab5511, PERM128_21);
+
+    let ab3333 = _mm256_permute2f128_ps(ab3377, ab7733, PERM128_03);
+    let ab7777 = _mm256_permute2f128_ps(ab3377, ab7733, PERM128_21);
+
+    ab[0] = ab0000;
+    ab[1] = ab1111;
+    ab[2] = ab2222;
+    ab[3] = ab3333;
+    ab[4] = ab4444;
+    ab[5] = ab5555;
+    ab[6] = ab6666;
+    ab[7] = ab7777;
+
+    macro_rules! c {
+        ($i:expr, $j:expr) => (c.offset(rsc * $i as isize + csc * $j as isize));
+    }
+
+    // C ← α A B + β C
+    let mut cv = [_mm256_setzero_ps(); MR];
+    if beta != 0. {
+        let betav = _mm256_set1_ps(beta);
+        // Read C
+        if csc == 1 {
+            loop_m!(i, cv[i] = _mm256_loadu_ps(c![i, 0]));
+        } else {
+            loop_m!(i, cv[i] = _mm256_setr_ps(*c![i, 0], *c![i, 1], *c![i, 2], *c![i, 3],
+                                              *c![i, 4], *c![i, 5], *c![i, 6], *c![i, 7]));
+        }
+        // Compute β C
+        loop_m!(i, cv[i] = _mm256_mul_ps(cv[i], betav));
+    }
+
+    let alphav = _mm256_set1_ps(alpha);
+
+    // Compute (α A B) + (β C)
+    loop_m!(i, cv[i] = _mm256_fmadd_ps(ab[i], alphav, cv[i]));
 
     // Store C back to memory
     if csc == 1 {
@@ -456,6 +708,7 @@ mod tests {
         }
 
         test_arch_kernels_x86! {
+            "fma", kernel_target_fma,
             "avx", kernel_target_avx,
             "sse2", kernel_target_sse2
         }


### PR DESCRIPTION
This uses fused multiply add via `_mm256_fmadd_{ps,pd}` to multiply and accumulate matrices in one go. The performance gains are impressive, as described in issue #35.

Fixes #31 
Fixes #35 
Fixes #38 