### PR TITLE
More flexible kernel selection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ install:
 # the main build
 script:
   - |
+      rustc --print cfg -Ctarget-cpu=native &&
       cargo build --target=$TARGET &&
       ([ -n "$BUILD_ONLY" ] || (
       cargo test --target=$TARGET &&

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -33,6 +33,8 @@ macro_rules! loop_n {
 
 impl GemmKernel for Gemm {
     type Elem = T;
+    const MR: usize = MR;
+    const NR: usize = NR;
 
     #[inline(always)]
     fn align_to() -> usize { 32 }

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use kernel::GemmKernel;
+use kernel::GemmSelect;
 use archparam;
 
 #[cfg(target_arch="x86")]
@@ -16,9 +17,14 @@ use std::arch::x86_64::*;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 use x86::{FusedMulAdd, AvxMulAdd, DMultiplyAdd};
 
-pub enum Gemm { }
+struct Gemm;
 
-pub type T = f64;
+type T = f64;
+
+#[inline]
+pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
+    return selector.select(Gemm);
+}
 
 const MR: usize = 8;
 const NR: usize = 4;

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -8,6 +8,7 @@
 
 use kernel::GemmKernel;
 use kernel::GemmSelect;
+use kernel::{U4, U8};
 use archparam;
 
 #[cfg(target_arch="x86")]
@@ -65,16 +66,12 @@ macro_rules! loop_n {
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 impl GemmKernel for KernelAvx {
     type Elem = T;
-    const MR: usize = MR;
-    const NR: usize = NR;
+
+    type MRTy = U8;
+    type NRTy = U4;
 
     #[inline(always)]
     fn align_to() -> usize { 32 }
-
-    #[inline(always)]
-    fn mr() -> usize { MR }
-    #[inline(always)]
-    fn nr() -> usize { NR }
 
     #[inline(always)]
     fn always_masked() -> bool { false }
@@ -104,16 +101,12 @@ impl GemmKernel for KernelAvx {
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 impl GemmKernel for KernelFma {
     type Elem = T;
-    const MR: usize = KernelAvx::MR;
-    const NR: usize = KernelAvx::NR;
+
+    type MRTy = <KernelAvx as GemmKernel>::MRTy;
+    type NRTy = <KernelAvx as GemmKernel>::NRTy;
 
     #[inline(always)]
     fn align_to() -> usize { KernelAvx::align_to() }
-
-    #[inline(always)]
-    fn mr() -> usize { MR }
-    #[inline(always)]
-    fn nr() -> usize { NR }
 
     #[inline(always)]
     fn always_masked() -> bool { KernelAvx::always_masked() }
@@ -143,16 +136,12 @@ impl GemmKernel for KernelFma {
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 impl GemmKernel for KernelSse2 {
     type Elem = T;
-    const MR: usize = 4;
-    const NR: usize = 4;
+
+    type MRTy = U4;
+    type NRTy = U4;
 
     #[inline(always)]
     fn align_to() -> usize { 16 }
-
-    #[inline(always)]
-    fn mr() -> usize { Self::MR }
-    #[inline(always)]
-    fn nr() -> usize { Self::NR }
 
     #[inline(always)]
     fn always_masked() -> bool { true }
@@ -181,16 +170,12 @@ impl GemmKernel for KernelSse2 {
 
 impl GemmKernel for KernelFallback {
     type Elem = T;
-    const MR: usize = 4;
-    const NR: usize = 4;
+
+    type MRTy = U4;
+    type NRTy = U4;
 
     #[inline(always)]
     fn align_to() -> usize { 0 }
-
-    #[inline(always)]
-    fn mr() -> usize { Self::MR }
-    #[inline(always)]
-    fn nr() -> usize { Self::NR }
 
     #[inline(always)]
     fn always_masked() -> bool { true }

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -17,13 +17,35 @@ use std::arch::x86_64::*;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 use x86::{FusedMulAdd, AvxMulAdd, DMultiplyAdd};
 
-struct Gemm;
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+struct KernelAvx;
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+struct KernelFma;
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+struct KernelSse2;
+struct KernelFallback;
 
 type T = f64;
 
+/// Detect which implementation to use and select it using the selector's
+/// .select(Kernel) method.
+///
+/// This function is called one or more times during a whole program's
+/// execution, it may be called for each gemm kernel invocation or fewer times.
 #[inline]
 pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
-    return selector.select(Gemm);
+    // dispatch to specific compiled versions
+    #[cfg(any(target_arch="x86", target_arch="x86_64"))]
+    {
+        if is_x86_feature_detected_!("fma") {
+            return selector.select(KernelFma);
+        } else if is_x86_feature_detected_!("avx") {
+            return selector.select(KernelAvx);
+        } else if is_x86_feature_detected_!("sse2") {
+            return selector.select(KernelSse2);
+        }
+    }
+    return selector.select(KernelFallback);
 }
 
 const MR: usize = 8;
@@ -36,8 +58,8 @@ macro_rules! loop_n {
     ($j:ident, $e:expr) => { loop4!($j, $e) };
 }
 
-
-impl GemmKernel for Gemm {
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+impl GemmKernel for KernelAvx {
     type Elem = T;
     const MR: usize = MR;
     const NR: usize = NR;
@@ -71,45 +93,131 @@ impl GemmKernel for Gemm {
         rsc: isize,
         csc: isize)
     {
-        kernel(k, alpha, a, b, beta, c, rsc, csc)
+        kernel_target_avx(k, alpha, a, b, beta, c, rsc, csc)
     }
 }
 
-/// matrix multiplication kernel
-///
-/// This does the matrix multiplication:
-///
-/// C ← α A B + β C
-///
-/// + k: length of data in a, b
-/// + a, b are packed
-/// + c has general strides
-/// + rsc: row stride of c
-/// + csc: col stride of c
-/// + if beta is 0, then c does not need to be initialized
-#[inline(never)]
-pub unsafe fn kernel(k: usize, alpha: T, a: *const T, b: *const T,
-                     beta: T, c: *mut T, rsc: isize, csc: isize)
-{
-    // dispatch to specific compiled versions
-    #[cfg(any(target_arch="x86", target_arch="x86_64"))]
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+impl GemmKernel for KernelFma {
+    type Elem = T;
+    const MR: usize = KernelAvx::MR;
+    const NR: usize = KernelAvx::NR;
+
+    #[inline(always)]
+    fn align_to() -> usize { KernelAvx::align_to() }
+
+    #[inline(always)]
+    fn mr() -> usize { MR }
+    #[inline(always)]
+    fn nr() -> usize { NR }
+
+    #[inline(always)]
+    fn always_masked() -> bool { KernelAvx::always_masked() }
+
+    #[inline(always)]
+    fn nc() -> usize { archparam::D_NC }
+    #[inline(always)]
+    fn kc() -> usize { archparam::D_KC }
+    #[inline(always)]
+    fn mc() -> usize { archparam::D_MC }
+
+    #[inline(always)]
+    unsafe fn kernel(
+        k: usize,
+        alpha: T,
+        a: *const T,
+        b: *const T,
+        beta: T,
+        c: *mut T,
+        rsc: isize,
+        csc: isize)
     {
-        if is_x86_feature_detected_!("fma") {
-            return kernel_target_fma(k, alpha, a, b, beta, c, rsc, csc);
-        } else if is_x86_feature_detected_!("avx") {
-            return kernel_target_avx(k, alpha, a, b, beta, c, rsc, csc);
-        } else if is_x86_feature_detected_!("sse2") {
-            return kernel_target_sse2(k, alpha, a, b, beta, c, rsc, csc);
-        }
+        kernel_target_fma(k, alpha, a, b, beta, c, rsc, csc)
     }
-    kernel_fallback_impl(k, alpha, a, b, beta, c, rsc, csc);
+}
+
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+impl GemmKernel for KernelSse2 {
+    type Elem = T;
+    const MR: usize = MR;
+    const NR: usize = NR;
+
+    #[inline(always)]
+    fn align_to() -> usize { 16 }
+
+    #[inline(always)]
+    fn mr() -> usize { Self::MR }
+    #[inline(always)]
+    fn nr() -> usize { Self::NR }
+
+    #[inline(always)]
+    fn always_masked() -> bool { true }
+
+    #[inline(always)]
+    fn nc() -> usize { archparam::D_NC }
+    #[inline(always)]
+    fn kc() -> usize { archparam::D_KC }
+    #[inline(always)]
+    fn mc() -> usize { archparam::D_MC }
+
+    #[inline(always)]
+    unsafe fn kernel(
+        k: usize,
+        alpha: T,
+        a: *const T,
+        b: *const T,
+        beta: T,
+        c: *mut T,
+        rsc: isize,
+        csc: isize)
+    {
+        kernel_target_sse2(k, alpha, a, b, beta, c, rsc, csc)
+    }
+}
+
+impl GemmKernel for KernelFallback {
+    type Elem = T;
+    const MR: usize = MR;
+    const NR: usize = NR;
+
+    #[inline(always)]
+    fn align_to() -> usize { 0 }
+
+    #[inline(always)]
+    fn mr() -> usize { Self::MR }
+    #[inline(always)]
+    fn nr() -> usize { Self::NR }
+
+    #[inline(always)]
+    fn always_masked() -> bool { true }
+
+    #[inline(always)]
+    fn nc() -> usize { archparam::D_NC }
+    #[inline(always)]
+    fn kc() -> usize { archparam::D_KC }
+    #[inline(always)]
+    fn mc() -> usize { archparam::D_MC }
+
+    #[inline(always)]
+    unsafe fn kernel(
+        k: usize,
+        alpha: T,
+        a: *const T,
+        b: *const T,
+        beta: T,
+        c: *mut T,
+        rsc: isize,
+        csc: isize)
+    {
+        kernel_fallback_impl(k, alpha, a, b, beta, c, rsc, csc)
+    }
 }
 
 #[inline]
 #[target_feature(enable="fma")]
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 unsafe fn kernel_target_fma(k: usize, alpha: T, a: *const T, b: *const T,
-                         beta: T, c: *mut T, rsc: isize, csc: isize)
+                            beta: T, c: *mut T, rsc: isize, csc: isize)
 {
     kernel_x86_avx::<FusedMulAdd>(k, alpha, a, b, beta, c, rsc, csc)
 }
@@ -118,7 +226,7 @@ unsafe fn kernel_target_fma(k: usize, alpha: T, a: *const T, b: *const T,
 #[target_feature(enable="avx")]
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 unsafe fn kernel_target_avx(k: usize, alpha: T, a: *const T, b: *const T,
-                         beta: T, c: *mut T, rsc: isize, csc: isize)
+                            beta: T, c: *mut T, rsc: isize, csc: isize)
 {
     kernel_x86_avx::<AvxMulAdd>(k, alpha, a, b, beta, c, rsc, csc)
 }
@@ -693,13 +801,17 @@ unsafe fn kernel_x86_avx<MA>(k: usize, alpha: T, a: *const T, b: *const T,
     }
 }
 
-#[inline(always)]
+#[inline]
 unsafe fn kernel_fallback_impl(k: usize, alpha: T, a: *const T, b: *const T,
                                    beta: T, c: *mut T, rsc: isize, csc: isize)
 {
+    const MR: usize = KernelFallback::MR;
+    const NR: usize = KernelFallback::NR;
     let mut ab: [[T; NR]; MR] = [[0.; NR]; MR];
     let mut a = a;
     let mut b = b;
+    debug_assert_eq!(alpha, 1., "Alpha must be 1 or is not masked");
+    debug_assert_eq!(beta, 0., "Beta must be 0 or is not masked");
 
     // Compute matrix multiplication into ab[i][j]
     unroll_by!(4 => k, {
@@ -714,11 +826,7 @@ unsafe fn kernel_fallback_impl(k: usize, alpha: T, a: *const T, b: *const T,
     }
 
     // set C = α A B + β C
-    if beta == 0. {
-        loop_n!(j, loop_m!(i, *c![i, j] = alpha * ab[i][j]));
-    } else {
-        loop_n!(j, loop_m!(i, *c![i, j] = *c![i, j] * beta + alpha * ab[i][j]));
-    }
+    loop_n!(j, loop_m!(i, *c![i, j] = alpha * ab[i][j]));
 }
 
 #[inline(always)]
@@ -734,43 +842,36 @@ mod tests {
     fn aligned_alloc<T>(elt: T, n: usize) -> Alloc<T> where T: Copy
     {
         unsafe {
-            Alloc::new(n, Gemm::align_to()).init_with(elt)
+            Alloc::new(n, KernelAvx::align_to()).init_with(elt)
         }
     }
 
     use super::T;
-    type KernelFn = unsafe fn(usize, T, *const T, *const T, T, *mut T, isize, isize);
 
-    fn test_a_kernel(_name: &str, kernel_fn: KernelFn) {
+    fn test_a_kernel<K: GemmKernel<Elem=T>>(_name: &str) {
         const K: usize = 4;
-        let mut a = aligned_alloc(1., MR * K);
-        let mut b = aligned_alloc(0., NR * K);
+        let mr = K::MR;
+        let nr = K::NR;
+        let mut a = aligned_alloc(1., mr * K);
+        let mut b = aligned_alloc(0., nr * K);
         for (i, x) in a.iter_mut().enumerate() {
             *x = i as _;
         }
 
         for i in 0..K {
-            b[i + i * NR] = 1.;
+            b[i + i * nr] = 1.;
         }
-        let mut c = [0.; MR * NR];
-
+        let mut c = vec![0.; mr * nr];
         unsafe {
-            // Column major matrix:
-            // row stride of c matrix, rsc = 1
-            // column stride of c matrix, csc = MR = 8
-            kernel_fn(K, 1., &a[0], &b[0], 0., &mut c[0], 1, MR as isize);
+            K::kernel(K, 1., &a[0], &b[0], 0., &mut c[0], 1, mr as isize);
+            // col major C
         }
         assert_eq!(&a[..], &c[..a.len()]);
     }
 
     #[test]
-    fn test_native_kernel() {
-        test_a_kernel("kernel", kernel);
-    }
-
-    #[test]
     fn test_kernel_fallback_impl() {
-        test_a_kernel("kernel", kernel_fallback_impl);
+        test_a_kernel::<KernelFallback>("kernel");
     }
 
     #[test]
@@ -787,13 +888,14 @@ mod tests {
     #[cfg(any(target_arch="x86", target_arch="x86_64"))]
     mod test_arch_kernels {
         use super::test_a_kernel;
+        use super::super::*;
         macro_rules! test_arch_kernels_x86 {
-            ($($feature_name:tt, $function_name:ident),*) => {
+            ($($feature_name:tt, $name:ident, $kernel_ty:ty),*) => {
                 $(
                 #[test]
-                fn $function_name() {
+                fn $name() {
                     if is_x86_feature_detected_!($feature_name) {
-                        test_a_kernel(stringify!($function_name), super::super::$function_name);
+                        test_a_kernel::<$kernel_ty>(stringify!($name));
                     } else {
                         println!("Skipping, host does not have feature: {:?}", $feature_name);
                     }
@@ -803,7 +905,9 @@ mod tests {
         }
 
         test_arch_kernels_x86! {
-            "sse2", kernel_target_sse2
+            "fma", fma, KernelFma,
+            "avx", avx, KernelAvx,
+            "sse2", sse2, KernelSse2
         }
     }
 }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -11,17 +11,16 @@ pub trait GemmKernel {
     type Elem: Element;
 
     /// Kernel rows
-    const MR: usize;
+    const MR: usize = Self::MRTy::VALUE;
     /// Kernel cols
-    const NR: usize;
+    const NR: usize = Self::NRTy::VALUE;
+    /// Kernel rows as const num type
+    type MRTy: ConstNum;
+    /// Kernel cols as const num type
+    type NRTy: ConstNum;
 
     /// align inputs to this
     fn align_to() -> usize;
-
-    /// Kernel rows
-    fn mr() -> usize;
-    /// Kernel cols
-    fn nr() -> usize;
 
     /// Whether to always use the masked wrapper around the kernel.
     ///
@@ -93,3 +92,13 @@ pub(crate) trait GemmSelect<T> {
               T: Element;
 }
 
+
+pub trait ConstNum {
+    const VALUE: usize;
+}
+
+pub struct U4;
+pub struct U8;
+
+impl ConstNum for U4 { const VALUE: usize = 4; }
+impl ConstNum for U8 { const VALUE: usize = 8; }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -10,6 +10,11 @@
 pub trait GemmKernel {
     type Elem: Element;
 
+    /// Kernel rows
+    const MR: usize;
+    /// Kernel cols
+    const NR: usize;
+
     /// align inputs to this
     fn align_to() -> usize;
 

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -84,3 +84,12 @@ impl Element for f64 {
         *self += alpha * a;
     }
 }
+
+/// Kernel selector
+pub(crate) trait GemmSelect<T> {
+    /// Call `select` with the selected kernel for this configuration
+    fn select<K>(self, kernel: K)
+        where K: GemmKernel<Elem=T>,
+              T: Element;
+}
+

--- a/src/loopmacros.rs
+++ b/src/loopmacros.rs
@@ -20,6 +20,14 @@ macro_rules! repeat {
     (8 $e:expr) => { $e;$e; $e;$e; $e;$e; $e;$e; };
 }
 
+#[cfg(debug_assertions)]
+macro_rules! loop4 {
+    ($i:ident, $e:expr) => {
+        for $i in 0..4 { $e }
+    }
+}
+
+#[cfg(not(debug_assertions))]
 macro_rules! loop4 {
     ($i:ident, $e:expr) => {{
         let $i = 0; $e;

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -51,11 +51,6 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
 }
 
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
-const MR: usize = 8;
-#[cfg(any(target_arch="x86", target_arch="x86_64"))]
-const NR: usize = 8;
-
-#[cfg(any(target_arch="x86", target_arch="x86_64"))]
 macro_rules! loop_m { ($i:ident, $e:expr) => { loop8!($i, $e) }; }
 #[cfg(test)]
 macro_rules! loop_n { ($j:ident, $e:expr) => { loop8!($j, $e) }; }
@@ -220,6 +215,9 @@ unsafe fn kernel_x86_avx<MA>(k: usize, alpha: T, a: *const T, b: *const T,
                              beta: T, c: *mut T, rsc: isize, csc: isize)
     where MA: SMultiplyAdd,
 {
+    const MR: usize = KernelAvx::MR;
+    const NR: usize = KernelAvx::NR;
+
     debug_assert_ne!(k, 0);
 
     let mut ab = [_mm256_setzero_ps(); MR];
@@ -541,7 +539,7 @@ mod tests {
 
     #[test]
     fn test_loop_m_n() {
-        let mut m = [[0; NR]; MR];
+        let mut m = [[0; KernelAvx::NR]; KernelAvx::MR];
         loop_m!(i, loop_n!(j, m[i][j] += 1));
         for arr in &m[..] {
             for elt in &arr[..] {

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -8,6 +8,7 @@
 
 use kernel::GemmKernel;
 use kernel::GemmSelect;
+use kernel::{U4, U8};
 use archparam;
 
 
@@ -63,15 +64,11 @@ macro_rules! loop_n { ($j:ident, $e:expr) => { loop8!($j, $e) }; }
 impl GemmKernel for KernelAvx {
     type Elem = T;
 
-    const MR: usize = MR;
-    const NR: usize = NR;
-    #[inline(always)]
-    fn align_to() -> usize { 32 }
+    type MRTy = U8;
+    type NRTy = U8;
 
     #[inline(always)]
-    fn mr() -> usize { MR }
-    #[inline(always)]
-    fn nr() -> usize { NR }
+    fn align_to() -> usize { 32 }
 
     #[inline(always)]
     fn always_masked() -> bool { false }
@@ -99,16 +96,11 @@ impl GemmKernel for KernelAvx {
 impl GemmKernel for KernelFma {
     type Elem = T;
 
-    const MR: usize = KernelAvx::MR;
-    const NR: usize = KernelAvx::NR;
+    type MRTy = <KernelAvx as GemmKernel>::MRTy;
+    type NRTy = <KernelAvx as GemmKernel>::NRTy;
 
     #[inline(always)]
     fn align_to() -> usize { KernelAvx::align_to() }
-
-    #[inline(always)]
-    fn mr() -> usize { MR }
-    #[inline(always)]
-    fn nr() -> usize { NR }
 
     #[inline(always)]
     fn always_masked() -> bool { KernelAvx::always_masked() }
@@ -136,15 +128,11 @@ impl GemmKernel for KernelFma {
 impl GemmKernel for KernelSse2 {
     type Elem = T;
 
-    const MR: usize = KernelFallback::MR;
-    const NR: usize = KernelFallback::NR;
-    #[inline(always)]
-    fn align_to() -> usize { 16 }
+    type MRTy = <KernelFallback as GemmKernel>::MRTy;
+    type NRTy = <KernelFallback as GemmKernel>::NRTy;
 
     #[inline(always)]
-    fn mr() -> usize { Self::MR }
-    #[inline(always)]
-    fn nr() -> usize { Self::NR }
+    fn align_to() -> usize { 16 }
 
     #[inline(always)]
     fn always_masked() -> bool { KernelFallback::always_masked() }
@@ -171,15 +159,11 @@ impl GemmKernel for KernelSse2 {
 impl GemmKernel for KernelFallback {
     type Elem = T;
 
-    const MR: usize = 8;
-    const NR: usize = 4;
-    #[inline(always)]
-    fn align_to() -> usize { 0 }
+    type MRTy = U8;
+    type NRTy = U4;
 
     #[inline(always)]
-    fn mr() -> usize { Self::MR }
-    #[inline(always)]
-    fn nr() -> usize { Self::NR }
+    fn align_to() -> usize { 0 }
 
     #[inline(always)]
     fn always_masked() -> bool { true }

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use kernel::GemmKernel;
+use kernel::GemmSelect;
 use archparam;
 
 
@@ -17,9 +18,14 @@ use std::arch::x86_64::*;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 use x86::{FusedMulAdd, AvxMulAdd, SMultiplyAdd};
 
-pub enum Gemm { }
+struct Gemm;
 
-pub type T = f32;
+type T = f32;
+
+#[inline]
+pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
+    return selector.select(Gemm);
+}
 
 const MR: usize = 8;
 const NR: usize = 8;

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -30,6 +30,8 @@ macro_rules! loop_n { ($j:ident, $e:expr) => { loop8!($j, $e) }; }
 impl GemmKernel for Gemm {
     type Elem = T;
 
+    const MR: usize = MR;
+    const NR: usize = NR;
     #[inline(always)]
     fn align_to() -> usize { 32 }
 


### PR DESCRIPTION
Allow separate GemmKernel implementations per feature, so that we can tweak kernel parameters per feature. This also allows us to restore the performance of the fallback kernels.

We introduce a selector trait and when entering for example `sgemm`, we pass control to `sgemm_kernel::detect`, and it selects which kernel implementation to use. Control passes back to the gemm module and it launches the `gemm_loop` using the selected kernel.

This approach allows us to insert a cache (ifunc strategy #23) in the gemm module if we want to cache the function pointer to avoid running detection many times. But it's unlikely that we are going to need that.

This is also an improvement since we don't need to run detection every kernel invocation! Repeated detection is just an atomic load and compare, so it's pretty cheap, but anyway.

This change slightly increases the amount of compiled code due to instantiating the gemm loop with multiple kernels, but it's a relatively little difference in compile time (adds +25% compile time in a crate that is already compiling *very* quickly, less than 3 seconds in release mode on my configuration).

We also add some ad-hoc types for static dimensions, so that the matrix packing function is instantiated appropriately for each kernel width, now that we have more diverse such.