### PR TITLE
Minor changes to kernel masking

### DIFF
--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -396,11 +396,11 @@ unsafe fn masked_kernel<T, K>(k: usize, alpha: T,
                 let cptr = c.stride_offset(rsc, i)
                             .stride_offset(csc, j);
                 if beta.is_zero() {
-                    *cptr = T::zero(); // initialize C
+                    *cptr = *ab; // initialize
                 } else {
                     *cptr *= beta;
+                    *cptr += *ab;
                 }
-                *cptr += *ab;
             }
             ab.inc();
         }

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -398,9 +398,9 @@ unsafe fn masked_kernel<T, K>(k: usize, alpha: T,
                 if beta.is_zero() {
                     *cptr = T::zero(); // initialize C
                 } else {
-                    (*cptr).scale_by(beta);
+                    *cptr *= beta;
                 }
-                (*cptr).add(*ab);
+                *cptr += *ab;
             }
             ab.inc();
         }
@@ -419,7 +419,7 @@ unsafe fn c_to_beta_c<T>(m: usize, n: usize, beta: T,
             if beta.is_zero() {
                 *cptr = T::zero(); // initialize C
             } else {
-                (*cptr).scale_by(beta);
+                *cptr *= beta;
             }
         }
     }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -6,6 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::ops::{AddAssign, MulAssign};
+
 /// General matrix multiply kernel
 pub trait GemmKernel {
     type Elem: Element;
@@ -57,36 +59,22 @@ pub trait GemmKernel {
         c: *mut Self::Elem, rsc: isize, csc: isize);
 }
 
-pub trait Element : Copy {
+pub trait Element : Copy + AddAssign + MulAssign + Send + Sync {
     fn zero() -> Self;
     fn one() -> Self;
     fn is_zero(&self) -> bool;
-    fn add(&mut self, a: Self);
-    fn scale_by(&mut self, x: Self);
 }
 
 impl Element for f32 {
     fn zero() -> Self { 0. }
     fn one() -> Self { 1. }
     fn is_zero(&self) -> bool { *self == 0. }
-    fn add(&mut self, x: Self) {
-        *self += x;
-    }
-    fn scale_by(&mut self, x: Self) {
-        *self *= x;
-    }
 }
 
 impl Element for f64 {
     fn zero() -> Self { 0. }
     fn one() -> Self { 1. }
     fn is_zero(&self) -> bool { *self == 0. }
-    fn add(&mut self, x: Self) {
-        *self += x;
-    }
-    fn scale_by(&mut self, x: Self) {
-        *self *= x;
-    }
 }
 
 /// Kernel selector


### PR DESCRIPTION
- Instead of setting "c = 0; c += ab", use `c = ab` directly
- Try to resolve some of the aliasing problems

Functions where we have multiple raw pointers often have the compiler confused about aliasing. In this case, `*cptr *= beta; *cptr += *ab;` had it compile to *2* reads of the value in `*cptr` when one would be enough. We could explicitly write the read value, operate, store back, but here we tried instead to insert a function that takes the `mask_buf` pointer as a shared reference (and those are marked noalias). This is a workaround that sometimes works..

Fallback kernel benchmark improvement:

```
 name               63 ns/iter  62 ns/iter  diff ns/iter  diff % 
 mat_mul_f32::m032  3,624       3,393               -231  -6.37% 
 mat_mul_f64::m032  6,410       6,110               -300  -4.68%
```

Avx kernel improvement with direct set:

```
 name               63 ns/iter  62 ns/iter  diff ns/iter  diff % 
 mat_mul_f32::m012  508         484                  -24  -4.72% 
 mat_mul_f32::m127  94,366      93,774              -592  -0.63% 
 mat_mul_f32::m261  785,958     786,113              155   0.02% 
 mat_mul_f64::m012  509         498                  -11  -2.16% 
 mat_mul_f64::m127  180,432     178,201           -2,231  -1.24%
```

(261 was a case that was added, but its use of the masked kernel is too minor to make us notice anything.)