### PR TITLE
Update rawpointer dependency to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ name = "benchmarks"
 harness = false
 
 [dependencies]
-rawpointer = "0.1"
+rawpointer = "0.2"
 
 [dev-dependencies]
 bencher = "0.1.2"


### PR DESCRIPTION
This is the latest version and syncs with the version ndarray will be using in the next release.