### PR TITLE
no_std support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,34 @@ matrix:
       env:
         TARGET=aarch64-unknown-linux-gnu
         BUILD_ONLY=1
+    - rust: 1.36.0
+      env: TARGET=thumbv6m-none-eabi
+      before_script:
+        - rustup target add $TARGET
+        - set -ex
+      script:
+        - cargo rustc --target=$TARGET --manifest-path=ensure_no_std/Cargo.toml
+    - rust: stable
+      env: TARGET=thumbv6m-none-eabi
+      before_script:
+        - rustup target add $TARGET
+        - set -ex
+      script:
+        - cargo rustc --target=$TARGET --manifest-path=ensure_no_std/Cargo.toml
+    - rust: beta
+      env: TARGET=thumbv6m-none-eabi
+      before_script:
+        - rustup target add $TARGET
+        - set -ex
+      script:
+        - cargo rustc --target=$TARGET --manifest-path=ensure_no_std/Cargo.toml
+    - rust: nightly
+      env: TARGET=thumbv6m-none-eabi
+      before_script:
+        - rustup target add $TARGET
+        - set -ex
+      script:
+        - cargo rustc --target=$TARGET --manifest-path=ensure_no_std/Cargo.toml
 env:
   global:
     - HOST=x86_64-unknown-linux-gnu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,11 @@ rawpointer = "0.2"
 bencher = "0.1.2"
 itertools = "0.8"
 
+[features]
+default = ["std"]
+
+std = []
+
 [profile.release]
 [profile.bench]
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,14 +1,12 @@
 extern crate matrixmultiply;
-pub use matrixmultiply::sgemm;
 pub use matrixmultiply::dgemm;
+pub use matrixmultiply::sgemm;
 
 #[macro_use]
 extern crate bencher;
 
-
 // Compute GFlop/s
 // by flop / s = 2 M N K / time
-
 
 benchmark_main!(mat_mul_f32, mat_mul_f64, layout_f32_032, layout_f64_032);
 
@@ -20,7 +18,7 @@ macro_rules! mat_mul {
             $(
             pub fn $name(bench: &mut Bencher)
             {
-                let a = vec![0.; $m * $n]; 
+                let a = vec![0.; $m * $n];
                 let b = vec![0.; $n * $k];
                 let mut c = vec![0.; $m * $k];
                 bench.iter(|| {
@@ -42,7 +40,7 @@ macro_rules! mat_mul {
     };
 }
 
-mat_mul!{mat_mul_f32, sgemm,
+mat_mul! {mat_mul_f32, sgemm,
     (m004, 4, 4, 4)
     (m006, 6, 6, 6)
     (m008, 8, 8, 8)
@@ -61,7 +59,7 @@ mat_mul!{mat_mul_f32, sgemm,
     */
 }
 
-mat_mul!{mat_mul_f64, dgemm,
+mat_mul! {mat_mul_f64, dgemm,
     (m004, 4, 4, 4)
     (m006, 6, 6, 6)
     (m008, 8, 8, 8)
@@ -79,12 +77,14 @@ mat_mul!{mat_mul_f64, dgemm,
     (mix128x10000x128, 128, 10000, 128)
     */
 }
-
 
 // benchmarks combinations of inputs using various layouts
 // row-major ("c") vs column-major ("f") experiments
 
-enum Layout { C, F }
+enum Layout {
+    C,
+    F,
+}
 use self::Layout::*;
 
 impl Layout {
@@ -106,7 +106,7 @@ macro_rules! gemm_layout {
 
             fn base(bench: &mut Bencher, al: Layout, bl: Layout, cl: Layout)
             {
-                let a = vec![0.; $m * $m]; 
+                let a = vec![0.; $m * $m];
                 let b = vec![0.; $m * $m];
                 let mut c = vec![0.; $m * $m];
                 let (rsa, csa) = al.strides($m, 1);
@@ -149,27 +149,35 @@ macro_rules! gemm_layout {
     };
 }
 
-gemm_layout!{layout_f32_032, sgemm,
+gemm_layout! {layout_f32_032, sgemm,
     (m032, 32)
 }
 
-gemm_layout!{layout_f64_032, dgemm,
+gemm_layout! {layout_f64_032, dgemm,
     (m032, 32)
 }
-
 
 use std::ops::{Add, Mul};
 
 trait Z {
     fn zero() -> Self;
 }
-impl Z for f32 { fn zero() -> Self { 0. } }
-impl Z for f64 { fn zero() -> Self { 0. } }
+impl Z for f32 {
+    fn zero() -> Self {
+        0.
+    }
+}
+impl Z for f64 {
+    fn zero() -> Self {
+        0.
+    }
+}
 
 // simple, slow, correct (hopefully) mat mul (Row Major)
 #[inline(never)]
 fn reference_mat_mul<A>(m: usize, k: usize, n: usize, a: &[A], b: &[A], c: &mut [A])
-    where A: Z + Add<Output=A> + Mul<Output=A> + Copy,
+where
+    A: Z + Add<Output = A> + Mul<Output = A> + Copy,
 {
     assert!(a.len() >= m * k);
     assert!(b.len() >= k * n);
@@ -179,8 +187,9 @@ fn reference_mat_mul<A>(m: usize, k: usize, n: usize, a: &[A], b: &[A], c: &mut 
         for j in 0..n {
             unsafe {
                 let celt = c.get_unchecked_mut(i * m + j);
-                *celt = (0..k).fold(A::zero(),
-                    move |s, x| s + *a.get_unchecked(i * k + x) * *b.get_unchecked(x * n + j));
+                *celt = (0..k).fold(A::zero(), move |s, x| {
+                    s + *a.get_unchecked(i * k + x) * *b.get_unchecked(x * n + j)
+                });
             }
         }
     }
@@ -194,7 +203,7 @@ macro_rules! ref_mat_mul {
             $(
             pub fn $name(bench: &mut Bencher)
             {
-                let a = vec![0. as $ty; $m * $n]; 
+                let a = vec![0. as $ty; $m * $n];
                 let b = vec![0.; $n * $k];
                 let mut c = vec![0.; $m * $k];
                 bench.iter(|| {
@@ -207,7 +216,7 @@ macro_rules! ref_mat_mul {
         benchmark_group!{ $modname, $($modname::$name),+ }
     };
 }
-ref_mat_mul!{ref_mat_mul_f32, f32,
+ref_mat_mul! {ref_mat_mul_f32, f32,
     (m004, 4, 4, 4)
     (m005, 5, 5, 5)
     (m006, 6, 6, 6)

--- a/blas-bench/benches/benchmarks.rs
+++ b/blas-bench/benches/benchmarks.rs
@@ -7,7 +7,7 @@ pub use matrixmultiply::dgemm;
 extern crate bencher;
 extern crate blas;
 
-use std::os::raw::c_int;
+use core::os::raw::c_int;
 
 
 #[allow(non_camel_case_types)]

--- a/ensure_no_std/.gitignore
+++ b/ensure_no_std/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/ensure_no_std/Cargo.toml
+++ b/ensure_no_std/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ensure_no_std"
+version = "0.1.0"
+authors = ["Geordon Worley <vadixidav@gmail.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+matrixmultiply = { path = "..", default-features = false }
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/ensure_no_std/src/main.rs
+++ b/ensure_no_std/src/main.rs
@@ -1,0 +1,16 @@
+// ensure_no_std/src/main.rs
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+
+/// This function is called on panic.
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    loop {}
+}
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    loop {}
+}

--- a/examples/usegemm.rs
+++ b/examples/usegemm.rs
@@ -5,6 +5,7 @@
 //
 // Jump down to the next place where it says EXAMPLE.
 
+extern crate core;
 extern crate itertools;
 extern crate matrixmultiply;
 
@@ -16,7 +17,7 @@ use itertools::{
     enumerate,
     repeat_n,
 };
-use std::fmt::{Display, Debug};
+use core::fmt::{Display, Debug};
 
 trait Float : Copy + Display + Debug + PartialEq {
     fn zero() -> Self;

--- a/src/aligned_alloc.rs
+++ b/src/aligned_alloc.rs
@@ -1,14 +1,19 @@
-
-use std::alloc;
-use std::alloc::{Layout, handle_alloc_error};
-use std::{mem, cmp};
+#[cfg(not(feature = "std"))]
+use alloc::alloc::{self, handle_alloc_error, Layout};
+use core::{cmp, mem};
+#[cfg(feature = "std")]
+use std::alloc::{self, handle_alloc_error, Layout};
 
 #[cfg(test)]
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 #[cfg(test)]
-use std::slice;
+use core::slice;
 
-pub(crate) struct Alloc<T> { ptr: *mut T, len: usize, align: usize }
+pub(crate) struct Alloc<T> {
+    ptr: *mut T,
+    len: usize,
+    align: usize,
+}
 
 impl<T> Alloc<T> {
     #[inline]
@@ -31,7 +36,9 @@ impl<T> Alloc<T> {
     }
 
     #[cfg(test)]
-    pub fn init_with(mut self, elt: T) -> Alloc<T> where T: Copy
+    pub fn init_with(mut self, elt: T) -> Alloc<T>
+    where
+        T: Copy,
     {
         for elt1 in &mut self[..] {
             *elt1 = elt;
@@ -40,13 +47,16 @@ impl<T> Alloc<T> {
     }
 
     #[inline]
-    pub fn ptr_mut(&mut self) -> *mut T { self.ptr }
+    pub fn ptr_mut(&mut self) -> *mut T {
+        self.ptr
+    }
 }
 
 impl<T> Drop for Alloc<T> {
     fn drop(&mut self) {
         unsafe {
-            let layout = Layout::from_size_align_unchecked(mem::size_of::<T>() * self.len, self.align);
+            let layout =
+                Layout::from_size_align_unchecked(mem::size_of::<T>() * self.len, self.align);
             alloc::dealloc(self.ptr as _, layout);
         }
     }
@@ -56,18 +66,13 @@ impl<T> Drop for Alloc<T> {
 impl<T> Deref for Alloc<T> {
     type Target = [T];
     fn deref(&self) -> &[T] {
-        unsafe {
-            slice::from_raw_parts(self.ptr, self.len)
-        }
+        unsafe { slice::from_raw_parts(self.ptr, self.len) }
     }
 }
 
 #[cfg(test)]
 impl<T> DerefMut for Alloc<T> {
     fn deref_mut(&mut self) -> &mut [T] {
-        unsafe {
-            slice::from_raw_parts_mut(self.ptr, self.len)
-        }
+        unsafe { slice::from_raw_parts_mut(self.ptr, self.len) }
     }
 }
-

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -12,9 +12,9 @@ use kernel::{U4, U8};
 use archparam;
 
 #[cfg(target_arch="x86")]
-use std::arch::x86::*;
+use core::arch::x86::*;
 #[cfg(target_arch="x86_64")]
-use std::arch::x86_64::*;
+use core::arch::x86_64::*;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 use x86::{FusedMulAdd, AvxMulAdd, DMultiplyAdd};
 
@@ -867,6 +867,8 @@ mod tests {
     mod test_arch_kernels {
         use super::test_a_kernel;
         use super::super::*;
+        #[cfg(features = "std")]
+        use std::println;
         macro_rules! test_arch_kernels_x86 {
             ($($feature_name:tt, $name:ident, $kernel_ty:ty),*) => {
                 $(
@@ -875,6 +877,7 @@ mod tests {
                     if is_x86_feature_detected_!($feature_name) {
                         test_a_kernel::<$kernel_ty>(stringify!($name));
                     } else {
+                        #[cfg(features = "std")]
                         println!("Skipping, host does not have feature: {:?}", $feature_name);
                     }
                 }

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::cmp::min;
-use std::mem::size_of;
-use std::ptr::copy_nonoverlapping;
+use core::cmp::min;
+use core::mem::size_of;
+use core::ptr::copy_nonoverlapping;
 
 use aligned_alloc::Alloc;
 

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::ops::{AddAssign, MulAssign};
+use core::ops::{AddAssign, MulAssign};
 
 /// General matrix multiply kernel
 pub trait GemmKernel {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,16 +5,16 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-//! 
+//!
 //! General matrix multiplication for f32, f64 matrices. Operates on matrices
 //! with general layout (they can use arbitrary row and column stride).
-//! 
+//!
 //! This crate uses the same macro/microkernel approach to matrix multiplication as
 //! the [BLIS][bl] project.
-//! 
+//!
 //! We presently provide a few good microkernels, portable and for x86-64, and
 //! only one operation: the general matrix-matrix multiplication (“gemm”).
-//! 
+//!
 //! [bl]: https://github.com/flame/blis
 //!
 //! ## Matrix Representation
@@ -58,29 +58,56 @@
 //!   - `avx`
 //!   - `sse2`
 //!
+//! ## Features
+//!
+//! This crate can be used without the standard library (`#![no_std]`) by
+//! disabling the default `std` feature. To do so, use this in your
+//! `Cargo.toml`:
+//!
+//! ```toml
+//! matrixmultiply = { version = "0.2", default-features = false }
+//! ```
+//!
+//! Runtime CPU feature detection is available only when `std` is enabled.
+//! Without the `std` feature, the crate uses special CPU features only if they
+//! are enabled at compile time. (To enable CPU features at compile time, pass
+//! the relevant
+//! [`target-cpu`](https://doc.rust-lang.org/rustc/codegen-options/index.html#target-cpu)
+//! or
+//! [`target-feature`](https://doc.rust-lang.org/rustc/codegen-options/index.html#target-feature)
+//! option to `rustc`.)
+//!
 //! ## Other Notes
 //!
 //! The functions in this crate are thread safe, as long as the destination
 //! matrix is distinct.
 
 #![doc(html_root_url = "https://docs.rs/matrixmultiply/0.2/")]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate core;
 
 extern crate rawpointer;
 
-#[macro_use] mod debugmacros;
-#[macro_use] mod loopmacros;
+#[macro_use]
+mod debugmacros;
+#[macro_use]
+mod loopmacros;
 mod archparam;
-mod kernel;
 mod gemm;
+mod kernel;
 
-mod util;
 mod aligned_alloc;
+mod util;
 
-#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[macro_use]
 mod x86;
-mod sgemm_kernel;
 mod dgemm_kernel;
+mod sgemm_kernel;
 
-pub use gemm::sgemm;
 pub use gemm::dgemm;
+pub use gemm::sgemm;

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -13,9 +13,9 @@ use archparam;
 
 
 #[cfg(target_arch="x86")]
-use std::arch::x86::*;
+use core::arch::x86::*;
 #[cfg(target_arch="x86_64")]
-use std::arch::x86_64::*;
+use core::arch::x86_64::*;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 use x86::{FusedMulAdd, AvxMulAdd, SMultiplyAdd};
 
@@ -499,6 +499,7 @@ unsafe fn at(ptr: *const T, i: usize) -> T {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::vec;
     use aligned_alloc::Alloc;
 
     fn aligned_alloc<K>(elt: K::Elem, n: usize) -> Alloc<K::Elem>
@@ -554,6 +555,8 @@ mod tests {
     mod test_arch_kernels {
         use super::test_a_kernel;
         use super::super::*;
+        #[cfg(features = "std")]
+        use std::println;
         macro_rules! test_arch_kernels_x86 {
             ($($feature_name:tt, $name:ident, $kernel_ty:ty),*) => {
                 $(
@@ -562,6 +565,7 @@ mod tests {
                     if is_x86_feature_detected_!($feature_name) {
                         test_a_kernel::<$kernel_ty>(stringify!($name));
                     } else {
+                        #[cfg(features = "std")]
                         println!("Skipping, host does not have feature: {:?}", $feature_name);
                     }
                 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::cmp::min;
+use core::cmp::min;
 
 pub struct RangeChunk { i: usize, n: usize, chunk: usize }
 

--- a/src/x86/macros.rs
+++ b/src/x86/macros.rs
@@ -10,11 +10,23 @@ macro_rules! compile_env_matches_or_is_empty {
 }
 
 macro_rules! is_x86_feature_detected_ {
-    ($name:tt) => {
-        // for testing purposes, we can make sure only one specific feature
-        // is enabled by setting MMTEST_FEATURE=featurename (all others
-        // disabled). This does not force it to be detected, it must also be.
-        compile_env_matches_or_is_empty!("MMTEST_FEATURE", $name) && is_x86_feature_detected!($name)
-    }
+    ($name:tt) => {{
+        #[cfg(feature="std")]
+        {
+            // For testing purposes, we can make sure only one specific feature
+            // is enabled by setting MMTEST_FEATURE=featurename (all others
+            // disabled). This does not force it to be detected, it must also be.
+             compile_env_matches_or_is_empty!("MMTEST_FEATURE", $name) && is_x86_feature_detected!($name)
+        }
+        #[cfg(not(feature="std"))]
+        {
+            // For testing purposes, we can make sure only one specific feature
+            // is enabled by setting MMTEST_FEATURE=featurename (all others
+            // disabled). This does not force it to be detected, it must also
+            // be. In the `no_std` case, the `is_86_feature_detected` macro is
+            // not available, so we have to fall back to checking whether the
+            // feature is enabled at compile-time.
+            compile_env_matches_or_is_empty!("MMTEST_FEATURE", $name) && cfg!(target_feature=$name)
+        }
+    }};
 }
-

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -1,8 +1,8 @@
 
 #[cfg(target_arch="x86")]
-use std::arch::x86::*;
+use core::arch::x86::*;
 #[cfg(target_arch="x86_64")]
-use std::arch::x86_64::*;
+use core::arch::x86_64::*;
 
 #[macro_use]
 mod macros;

--- a/tests/sgemm.rs
+++ b/tests/sgemm.rs
@@ -1,3 +1,4 @@
+extern crate core;
 extern crate itertools;
 extern crate matrixmultiply;
 
@@ -9,7 +10,7 @@ use itertools::{
     enumerate,
     repeat_n,
 };
-use std::fmt::{Display, Debug};
+use core::fmt::{Display, Debug};
 
 trait Float : Copy + Display + Debug + PartialEq {
     fn zero() -> Self;


### PR DESCRIPTION
This is the follow-up to #46. I fixed the build issue with the benchmark trying to use core when it is using std. I also added CI tests for no_std. If CI fails, I will make additional changes. I have not previously used Travis CI, so I don't know if what I wrote will work, but that is what CI is for :smiley:.

Closes #46 