### PR TITLE
Add threading support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,14 +113,17 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - name: Cache cargo plugins
+        id: cache
         uses: actions/cache@v1
         with:
           path: ~/.cargo/bin/
           key: ${{ runner.os }}-cargo-plugins
       - name: Install cross
-        run: cargo install cross || true
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: cargo install cross
       - name: Tests
         run: cross test --target "${{ matrix.target }}"
         env:
           MMTEST_FAST_TEST: 1
+          RUSTFLAGS: -Copt-level=2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - rust: 1.28.0  # MSRV
-            experimental: false
+            experimental: true
             target: x86_64-unknown-linux-gnu
             deps: true
           - rust: 1.42.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.28.0  # MSRV
-            experimental: true
-            target: x86_64-unknown-linux-gnu
-          - rust: 1.42.0
+          - rust: 1.41.1  # MSRV
             experimental: false
             target: x86_64-unknown-linux-gnu
           - rust: stable
@@ -80,7 +77,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.36.0  # MSRV
+          - rust: 1.41.1  # MSRV
             experimental: false
             target: thumbv6m-none-eabi
           - rust: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ name: Continuous integration
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  MATMUL_NUM_THREADS: 4
 
 jobs:
   tests:
@@ -28,6 +29,7 @@ jobs:
           - rust: stable
             experimental: false
             target: x86_64-unknown-linux-gnu
+            features: threading
             deps: true
             test_examples: yes
           - rust: nightly
@@ -37,6 +39,7 @@ jobs:
             deps: true
           - rust: nightly
             target: x86_64-unknown-linux-gnu
+            features: threading
             mmtest_feature: fma
             experimental: false
             deps: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,31 +21,26 @@ jobs:
           - rust: 1.28.0  # MSRV
             experimental: true
             target: x86_64-unknown-linux-gnu
-            deps: true
           - rust: 1.42.0
             experimental: false
             target: x86_64-unknown-linux-gnu
-            deps: true
           - rust: stable
             experimental: false
             target: x86_64-unknown-linux-gnu
             features: threading
-            deps: true
             test_examples: yes
           - rust: nightly
             experimental: false
             target: x86_64-unknown-linux-gnu
             mmtest_feature: avx
-            deps: true
           - rust: nightly
             target: x86_64-unknown-linux-gnu
             features: threading
             mmtest_feature: fma
             experimental: false
-            deps: true
           - rust: nightly
             target: i686-unknown-linux-gnu
-            deps: |
+            install_deps: |
               sudo apt-get update
               sudo apt-get install -y gcc-multilib
             experimental: false
@@ -59,7 +54,8 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - name: Install dependencies
-        run: ${{ matrix.deps }}
+        if: matrix.install_deps
+        run: ${{ matrix.install_deps }}
       - name: Tests
         run: |
           rustc -C target-cpu=native --print cfg
@@ -67,11 +63,11 @@ jobs:
           cargo test -v --tests --lib --no-fail-fast --features "${{ matrix.features }}" --target "${{ matrix.target }}"
           cargo test -v  --tests --lib --release --no-fail-fast --features "${{ matrix.features }}" --target "${{ matrix.target }}"
       - name: Test examples
-        if: ${{ matrix.test_examples }}
+        if: matrix.test_examples
         run: |
           cargo test -v --examples --features "${{ matrix.features }}" --target "${{ matrix.target }}"
       - name: Test specific feature
-        if: ${{ matrix.mmtest_feature }}
+        if: matrix.mmtest_feature
         env:
           MMTEST_FEATURE: ${{ matrix.mmtest_feature }}
           MMTEST_ENSUREFEATURE: 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ harness = false
 [dependencies]
 rawpointer = "0.2"
 
+thread-tree = { version = "0.3", optional = true }
+once_cell = { version = "1.5", optional = true }
+
 [dev-dependencies]
 bencher = "0.1.2"
 itertools = "0.8"
@@ -36,6 +39,7 @@ itertools = "0.8"
 [features]
 default = ["std"]
 
+threading = ["thread-tree", "std", "once_cell"]
 std = []
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rawpointer = "0.2"
 
 thread-tree = { version = "0.3", optional = true }
 once_cell = { version = "1.5", optional = true }
+num_cpus = { version = "1.13", optional = true }
 
 [dev-dependencies]
 bencher = "0.1.2"
@@ -39,7 +40,7 @@ itertools = "0.8"
 [features]
 default = ["std"]
 
-threading = ["thread-tree", "std", "once_cell"]
+threading = ["thread-tree", "std", "once_cell", "num_cpus"]
 std = []
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,9 @@ threading = ["thread-tree", "std", "once_cell"]
 std = []
 
 [profile.release]
+debug = true
 [profile.bench]
+debug = true
 
 [package.metadata.release]
 no-dev-version = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "matrixmultiply"
+edition = "2018"
 version = "0.2.4"
 authors = [
     "bluss",

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -14,7 +14,7 @@ macro_rules! mat_mul {
     ($modname:ident, $gemm:ident, $(($name:ident, $m:expr, $n:expr, $k:expr))+) => {
         mod $modname {
             use bencher::{Bencher};
-            use $gemm;
+            use crate::$gemm;
             $(
             pub fn $name(bench: &mut Bencher)
             {
@@ -101,7 +101,7 @@ macro_rules! gemm_layout {
         mod $modname {
             use bencher::{Bencher};
             use super::Layout::{self, *};
-            use $gemm;
+            use crate::$gemm;
             $(
 
             fn base(bench: &mut Bencher, al: Layout, bl: Layout, cl: Layout)

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -12,10 +12,14 @@ use matrixmultiply::{sgemm, dgemm};
 use itertools::Itertools;
 
 fn main() -> Result<(), String> {
+    run_main(std::env::args())
+}
+
+fn run_main(args: impl IntoIterator<Item=String>) -> Result<(), String> {
     #[cfg(debug_assertions)]
     eprintln!("Warning: running benchmark with debug assertions");
 
-    let opts = match parse_args() {
+    let opts = match parse_args(args) {
         Ok(o) => o,
         Err(e) => {
             eprintln!("Usage: <command> m-size k-size n-size [float-type layout-types csv-format]");
@@ -117,9 +121,9 @@ struct Options {
     use_csv: bool,
 }
 
-fn parse_args() -> Result<Options, String> {
+fn parse_args(args: impl IntoIterator<Item=String>) -> Result<Options, String> {
     let mut opts = Options::default();
-    let mut args = std::env::args();
+    let mut args = args.into_iter();
     let _ = args.next();
     opts.m = args.next().ok_or("Expected argument".to_string())?
         .parse::<usize>().map_err(|e| e.to_string())?;
@@ -329,3 +333,7 @@ fn fmt_thousands_sep(mut n: u64, sep: &str) -> String {
     output
 }
 
+#[test]
+fn test_benchmark() {
+    run_main("ignored 128 128 128 f64 fcc".split_whitespace().map(str::to_string)).unwrap();
+}

--- a/src/aligned_alloc.rs
+++ b/src/aligned_alloc.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "std"))]
-use alloc::alloc::{self, handle_alloc_error, Layout};
+use ::alloc::alloc::{self, handle_alloc_error, Layout};
 use core::{cmp, mem};
 #[cfg(feature = "std")]
 use std::alloc::{self, handle_alloc_error, Layout};

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -6,18 +6,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use kernel::GemmKernel;
-use kernel::GemmSelect;
+use crate::kernel::GemmKernel;
+use crate::kernel::GemmSelect;
 #[allow(unused)]
-use kernel::{U4, U8};
-use archparam;
+use crate::kernel::{U4, U8};
+use crate::archparam;
 
 #[cfg(target_arch="x86")]
 use core::arch::x86::*;
 #[cfg(target_arch="x86_64")]
 use core::arch::x86_64::*;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
-use x86::{FusedMulAdd, AvxMulAdd, DMultiplyAdd};
+use crate::x86::{FusedMulAdd, AvxMulAdd, DMultiplyAdd};
 
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 struct KernelAvx;
@@ -813,7 +813,7 @@ unsafe fn at(ptr: *const T, i: usize) -> T {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aligned_alloc::Alloc;
+    use crate::aligned_alloc::Alloc;
 
     fn aligned_alloc<K>(elt: K::Elem, n: usize) -> Alloc<K::Elem>
         where K: GemmKernel,

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -10,17 +10,17 @@ use core::cmp::min;
 use core::mem::size_of;
 use core::ptr::copy_nonoverlapping;
 
-use aligned_alloc::Alloc;
+use crate::aligned_alloc::Alloc;
 
-use util::range_chunk;
-use util::round_up_to;
+use crate::util::range_chunk;
+use crate::util::round_up_to;
 
-use kernel::ConstNum;
-use kernel::Element;
-use kernel::GemmKernel;
-use kernel::GemmSelect;
-use sgemm_kernel;
-use dgemm_kernel;
+use crate::kernel::ConstNum;
+use crate::kernel::Element;
+use crate::kernel::GemmKernel;
+use crate::kernel::GemmSelect;
+use crate::sgemm_kernel;
+use crate::dgemm_kernel;
 use rawpointer::PointerExt;
 
 /// General matrix multiplication (f32)

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::cell::RefCell;
 use core::cmp::min;
 use core::mem::size_of;
 use core::ptr::copy_nonoverlapping;
@@ -20,6 +21,7 @@ use crate::kernel::ConstNum;
 use crate::kernel::Element;
 use crate::kernel::GemmKernel;
 use crate::kernel::GemmSelect;
+use crate::threading::{NTHREADS, THREADPOOL, ThreadPoolCtx, LoopThreadConfig};
 use crate::sgemm_kernel;
 use crate::dgemm_kernel;
 use rawpointer::PointerExt;
@@ -177,9 +179,14 @@ unsafe fn gemm_loop<K>(
     let b = Ptr(b);
     let c = Ptr(c);
 
-    let (mut packing_buffer, bp_offset) = make_packing_buffer::<K>(m, k, n);
+    let thread_config = LoopThreadConfig::new::<K>(m, k, n, *NTHREADS);
+    let nap = thread_config.loop3 as usize; // number of A packing buffers
+
+    let (mut packing_buffer, ap_size) = make_packing_buffer::<K>(m, k, n, nap);
     let app = Ptr(packing_buffer.ptr_mut());
-    let bpp = app.add(bp_offset);
+    let bpp = app.add(ap_size * nap);
+
+    let tp = THREADPOOL.top();
 
     // LOOP 5: split n into nc parts (B, C)
     for (l5, nc) in range_chunk(n, knc) {
@@ -188,6 +195,8 @@ unsafe fn gemm_loop<K>(
         let c = c.stride_offset(csc, knc * l5);
 
         // LOOP 4: split k in kc parts (A, B)
+        // This particular loop can't be parallelized because the
+        // C chunk (writable) is shared between iterations.
         for (l4, kc) in range_chunk(k, kkc) {
             dprint!("LOOP 4, {}, kc={}", l4, kc);
             let b = b.stride_offset(rsb, kkc * l4);
@@ -200,23 +209,40 @@ unsafe fn gemm_loop<K>(
             let betap = if l4 == 0 { beta } else { <_>::one() };
 
             // LOOP 3: split m into mc parts (A, C)
-            for (l3, mc) in range_chunk(m, kmc) {
-                dprint!("LOOP 3, {}, mc={}", l3, mc);
-                let a = a.stride_offset(rsa, kmc * l3);
-                let c = c.stride_offset(rsc, kmc * l3);
+            range_chunk(m, kmc)
+                .parallel(thread_config.loop3, tp)
+                .thread_local(move |i, _nt| {
+                    // a packing buffer A~ per thread
+                    debug_assert!(i < nap);
+                    app.add(ap_size * i)
+                })
+                .for_each(move |tp, &mut app, l3, mc| {
+                    dprint!("LOOP 3, {}, mc={}", l3, mc);
+                    let a = a.stride_offset(rsa, kmc * l3);
+                    let c = c.stride_offset(rsc, kmc * l3);
 
-                // Pack A -> A~
-                pack::<K::MRTy, _>(kc, mc, app.ptr(), a.ptr(), rsa, csa);
+                    // Pack A -> A~
+                    pack::<K::MRTy, _>(kc, mc, app.ptr(), a.ptr(), rsa, csa);
 
-                // LOOP 2 and 1
-                gemm_packed::<K>(nc, kc, mc,
-                                 alpha,
-                                 app.to_const(), bpp.to_const(),
-                                 betap,
-                                 c, rsc, csc);
-            }
+                    // LOOP 2 and 1
+                    gemm_packed::<K>(nc, kc, mc,
+                                     alpha,
+                                     app.to_const(), bpp.to_const(),
+                                     betap,
+                                     c, rsc, csc,
+                                     tp, thread_config);
+                });
         }
     }
+}
+
+// set up buffer for masked (redirected output of) kernel
+const KERNEL_MAX_SIZE: usize = 8 * 8 * 4;
+const KERNEL_MAX_ALIGN: usize = 32;
+const KERNEL_MASK_BUF_SIZE: usize = KERNEL_MAX_SIZE + KERNEL_MAX_ALIGN - 1;
+
+thread_local! {
+    pub static MASK_BUF: RefCell<[u8; KERNEL_MASK_BUF_SIZE]> = RefCell::new([0; KERNEL_MASK_BUF_SIZE]);
 }
 
 /// Loops 1 and 2 around the µ-kernel
@@ -230,39 +256,47 @@ unsafe fn gemm_packed<K>(nc: usize, kc: usize, mc: usize,
                          alpha: K::Elem,
                          app: Ptr<*const K::Elem>, bpp: Ptr<*const K::Elem>,
                          beta: K::Elem,
-                         c: Ptr<*mut K::Elem>, rsc: isize, csc: isize)
+                         c: Ptr<*mut K::Elem>, rsc: isize, csc: isize,
+                         tp: ThreadPoolCtx, thread_config: LoopThreadConfig)
     where K: GemmKernel,
 {
     let mr = K::MR;
     let nr = K::NR;
-    // make a mask buffer that fits 8 x 8 f32 and 8 x 4 f64 kernels and alignment
-    assert!(mr * nr * size_of::<K::Elem>() <= 256 && K::align_to() <= 32);
-    let mut mask_buf = [0u8; 256 + 31];
-    let mask_ptr = align_ptr(32, mask_buf.as_mut_ptr()) as *mut K::Elem;
+    // check for the mask buffer that fits 8 x 8 f32 and 8 x 4 f64 kernels and alignment
+    assert!(mr * nr * size_of::<K::Elem>() <= KERNEL_MAX_SIZE && K::align_to() <= KERNEL_MAX_ALIGN);
 
     // LOOP 2: through micropanels in packed `b` (B~, C)
-    for (l2, nr_) in range_chunk(nc, nr) {
-        let bpp = bpp.stride_offset(1, kc * nr * l2);
-        let c = c.stride_offset(csc, nr * l2);
+    range_chunk(nc, nr)
+        .parallel(thread_config.loop2, tp)
+        .thread_local(|_i, _nt| {
+            MASK_BUF.with(|buf| {
+                let ptr = buf.borrow_mut().as_mut_ptr();
+                let mask_ptr = align_ptr(32, ptr) as *mut K::Elem;
+                mask_ptr
+            })
+        })
+        .for_each(move |_tp, &mut mask_ptr, l2, nr_| {
+            let bpp = bpp.stride_offset(1, kc * nr * l2);
+            let c = c.stride_offset(csc, nr * l2);
 
-        // LOOP 1: through micropanels in packed `a` while `b` is constant (A~, C)
-        for (l1, mr_) in range_chunk(mc, mr) {
-            let app = app.stride_offset(1, kc * mr * l1);
-            let c = c.stride_offset(rsc, mr * l1);
+            // LOOP 1: through micropanels in packed `a` while `b` is constant (A~, C)
+            for (l1, mr_) in range_chunk(mc, mr) {
+                let app = app.stride_offset(1, kc * mr * l1);
+                let c = c.stride_offset(rsc, mr * l1);
 
-            // GEMM KERNEL
-            // NOTE: For the rust kernels, it performs better to simply
-            // always use the masked kernel function!
-            if K::always_masked() || nr_ < nr || mr_ < mr {
-                masked_kernel::<_, K>(kc, alpha, &*app.ptr(), &*bpp.ptr(),
-                                      beta, &mut *c.ptr(), rsc, csc,
-                                      mr_, nr_, mask_ptr);
-                continue;
-            } else {
-                K::kernel(kc, alpha, app.ptr(), bpp.ptr(), beta, c.ptr(), rsc, csc);
+                // GEMM KERNEL
+                // NOTE: For the rust kernels, it performs better to simply
+                // always use the masked kernel function!
+                if K::always_masked() || nr_ < nr || mr_ < mr {
+                    masked_kernel::<_, K>(kc, alpha, &*app.ptr(), &*bpp.ptr(),
+                                          beta, &mut *c.ptr(), rsc, csc,
+                                          mr_, nr_, mask_ptr);
+                    continue;
+                } else {
+                    K::kernel(kc, alpha, app.ptr(), bpp.ptr(), beta, c.ptr(), rsc, csc);
+                }
             }
-        }
-    }
+        });
 }
 
 /// Allocate a vector of uninitialized data to be used for both packing buffers.
@@ -272,8 +306,10 @@ unsafe fn gemm_packed<K>(nc: usize, kc: usize, mc: usize,
 /// but we can make them smaller if the matrix is smaller than this (just ensure
 /// we have rounded up to a multiple of the kernel size).
 ///
-/// Return packing buffer and offset to start of b
-unsafe fn make_packing_buffer<K>(m: usize, k: usize, n: usize) -> (Alloc<K::Elem>, usize)
+/// na: Number of buffers to alloc for A
+///
+/// Return packing buffer and size of A~ (The offset to B~ is A~ size times `na`).
+unsafe fn make_packing_buffer<K>(m: usize, k: usize, n: usize, na: usize) -> (Alloc<K::Elem>, usize)
     where K: GemmKernel,
 {
     // max alignment requirement is a multiple of min(MR, NR) * sizeof<Elem>
@@ -283,14 +319,16 @@ unsafe fn make_packing_buffer<K>(m: usize, k: usize, n: usize) -> (Alloc<K::Elem
     let n = min(n, K::nc());
     // round up k, n to multiples of mr, nr
     // round up to multiple of kc
+    debug_assert_ne!(na, 0);
+    debug_assert!(na <= 128);
     let apack_size = k * round_up_to(m, K::MR);
     let bpack_size = k * round_up_to(n, K::NR);
-    let nelem = apack_size + bpack_size;
+    let nelem = apack_size * na + bpack_size;
 
     dprint!("packed nelem={}, apack={}, bpack={},
-             m={} k={} n={}",
+             m={} k={} n={}, na={}",
              nelem, apack_size, bpack_size,
-             m,k,n);
+             m,k,n, na);
 
     (Alloc::new(nelem, K::align_to()), apack_size)
 }

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(feature="std")]
 use core::cell::RefCell;
 use core::cmp::min;
 use core::mem::size_of;
@@ -241,6 +242,9 @@ const KERNEL_MAX_SIZE: usize = 8 * 8 * 4;
 const KERNEL_MAX_ALIGN: usize = 32;
 const KERNEL_MASK_BUF_SIZE: usize = KERNEL_MAX_SIZE + KERNEL_MAX_ALIGN - 1;
 
+// Use thread local if we can; this is faster even in the single threaded case because
+// it is possible to skip zeroing out the array.
+#[cfg(feature = "std")]
 thread_local! {
     pub static MASK_BUF: RefCell<[u8; KERNEL_MASK_BUF_SIZE]> = RefCell::new([0; KERNEL_MASK_BUF_SIZE]);
 }
@@ -265,15 +269,24 @@ unsafe fn gemm_packed<K>(nc: usize, kc: usize, mc: usize,
     // check for the mask buffer that fits 8 x 8 f32 and 8 x 4 f64 kernels and alignment
     assert!(mr * nr * size_of::<K::Elem>() <= KERNEL_MAX_SIZE && K::align_to() <= KERNEL_MAX_ALIGN);
 
+    #[cfg(not(feature = "std"))]
+    let mut mask_buf: [u8; KERNEL_MASK_BUF_SIZE] = [0; KERNEL_MASK_BUF_SIZE];
+
     // LOOP 2: through micropanels in packed `b` (B~, C)
     range_chunk(nc, nr)
         .parallel(thread_config.loop2, tp)
         .thread_local(|_i, _nt| {
-            MASK_BUF.with(|buf| {
-                let ptr = buf.borrow_mut().as_mut_ptr();
-                let mask_ptr = align_ptr(32, ptr) as *mut K::Elem;
-                mask_ptr
-            })
+            let ptr;
+            #[cfg(not(feature = "std"))]
+            {
+                debug_assert_eq!(_nt, 1);
+                ptr = mask_buf.as_mut_ptr();
+            }
+            #[cfg(feature = "std")]
+            {
+                ptr = MASK_BUF.with(|buf| buf.borrow_mut().as_mut_ptr());
+            }
+            align_ptr(KERNEL_MAX_ALIGN, ptr) as *mut K::Elem
         })
         .for_each(move |_tp, &mut mask_ptr, l2, nr_| {
             let bpp = bpp.stride_offset(1, kc * nr * l2);

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -180,7 +180,7 @@ unsafe fn gemm_loop<K>(
     let c = Ptr(c);
 
     let thread_config = LoopThreadConfig::new::<K>(m, k, n, *NTHREADS);
-    let nap = thread_config.loop3 as usize; // number of A packing buffers
+    let nap = thread_config.num_pack_a();
 
     let (mut packing_buffer, ap_size) = make_packing_buffer::<K>(m, k, n, nap);
     let app = Ptr(packing_buffer.ptr_mut());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,9 +83,11 @@
 //!
 //! ### `threading`
 //!
-//! `threading` is optional
+//! `threading` is an optional crate feature
 //!
-//! Threading enables multithreading for the operations.
+//! Threading enables multithreading for the operations. The environment variable
+//! `MATMUL_NUM_THREADS` decides how many threads are used at maximum. At the moment 1-4 are
+//! supported and the default is 1.
 //!
 //! ## Other Notes
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,5 +109,5 @@ mod x86;
 mod dgemm_kernel;
 mod sgemm_kernel;
 
-pub use gemm::dgemm;
-pub use gemm::sgemm;
+pub use crate::gemm::dgemm;
+pub use crate::gemm::sgemm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ mod loopmacros;
 mod archparam;
 mod gemm;
 mod kernel;
+mod ptr;
 
 mod aligned_alloc;
 mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@
 //!
 //! Threading enables multithreading for the operations. The environment variable
 //! `MATMUL_NUM_THREADS` decides how many threads are used at maximum. At the moment 1-4 are
-//! supported and the default is 1.
+//! supported and the default is the number of physical cpus (as detected by `num_cpus`).
 //!
 //! ## Other Notes
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,10 @@
 //!
 //! ## Features
 //!
+//! ### `std`
+//!
+//! `std` is enabled by default.
+//!
 //! This crate can be used without the standard library (`#![no_std]`) by
 //! disabling the default `std` feature. To do so, use this in your
 //! `Cargo.toml`:
@@ -77,6 +81,12 @@
 //! [`target-feature`](https://doc.rust-lang.org/rustc/codegen-options/index.html#target-feature)
 //! option to `rustc`.)
 //!
+//! ### `threading`
+//!
+//! `threading` is optional
+//!
+//! Threading enables multithreading for the operations.
+//!
 //! ## Other Notes
 //!
 //! The functions in this crate are thread safe, as long as the destination
@@ -90,8 +100,6 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate core;
 
-extern crate rawpointer;
-
 #[macro_use]
 mod debugmacros;
 #[macro_use]
@@ -100,6 +108,7 @@ mod archparam;
 mod gemm;
 mod kernel;
 mod ptr;
+mod threading;
 
 mod aligned_alloc;
 mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,12 @@
 //!
 //! The functions in this crate are thread safe, as long as the destination
 //! matrix is distinct.
+//!
+//! ## Rust Version
+//!
+//! This version requires Rust 1.41.1 or later; the crate follows a carefully
+//! considered upgrade policy, where updating the minimum Rust version is not a breaking
+//! change.
 
 #![doc(html_root_url = "https://docs.rs/matrixmultiply/0.2/")]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/src/loopmacros.rs
+++ b/src/loopmacros.rs
@@ -93,6 +93,7 @@ macro_rules! unroll_by_with_last {
     }}
 }
 
+#[allow(unused)]
 #[cfg(not(debug_assertions))]
 macro_rules! unroll_by_with_last {
     ($by:tt => $ntimes:expr, $is_last:ident, $e:expr) => {{

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -1,0 +1,49 @@
+
+use rawpointer::PointerExt;
+
+/// A Send + Sycn raw pointer wrapper
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub(crate) struct Ptr<T> { ptr: T }
+unsafe impl<T> Sync for Ptr<*const T> { }
+unsafe impl<T> Sync for Ptr<*mut T> { }
+unsafe impl<T> Send for Ptr<*const T> { }
+unsafe impl<T> Send for Ptr<*mut T> { }
+
+/// Create a Ptr
+///
+/// # Safety
+///
+/// Unsafe since it is thread safety critical to use the raw pointer correctly.
+#[allow(non_snake_case)]
+pub(crate) unsafe fn Ptr<T>(ptr: T) -> Ptr<T> { Ptr { ptr } }
+
+impl<T> Ptr<T> {
+    /// Get the pointer
+    pub(crate) fn ptr(self) -> T
+        where T: Copy
+    {
+        self.ptr
+    }
+}
+
+impl<T> Ptr<*mut T> {
+    /// Get as *const T
+    pub(crate) fn to_const(self) -> Ptr<*const T> {
+        Ptr { ptr: self.ptr }
+    }
+}
+
+impl<T> PointerExt for Ptr<*const T> {
+    #[inline(always)]
+    unsafe fn offset(self, i: isize) -> Self {
+        Ptr(self.ptr.offset(i))
+    }
+}
+
+impl<T> PointerExt for Ptr<*mut T> {
+    #[inline(always)]
+    unsafe fn offset(self, i: isize) -> Self {
+        Ptr(self.ptr.offset(i))
+    }
+}

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -6,10 +6,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use kernel::GemmKernel;
-use kernel::GemmSelect;
-use kernel::{U4, U8};
-use archparam;
+use crate::kernel::GemmKernel;
+use crate::kernel::GemmSelect;
+use crate::kernel::{U4, U8};
+use crate::archparam;
 
 
 #[cfg(target_arch="x86")]
@@ -17,7 +17,7 @@ use core::arch::x86::*;
 #[cfg(target_arch="x86_64")]
 use core::arch::x86_64::*;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
-use x86::{FusedMulAdd, AvxMulAdd, SMultiplyAdd};
+use crate::x86::{FusedMulAdd, AvxMulAdd, SMultiplyAdd};
 
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 struct KernelAvx;
@@ -500,7 +500,7 @@ unsafe fn at(ptr: *const T, i: usize) -> T {
 mod tests {
     use super::*;
     use std::vec;
-    use aligned_alloc::Alloc;
+    use crate::aligned_alloc::Alloc;
 
     fn aligned_alloc<K>(elt: K::Elem, n: usize) -> Alloc<K::Elem>
         where K: GemmKernel,

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -107,37 +107,41 @@ impl LoopThreadConfig {
                 return default_config;
             }
 
-            // use a heuristic to try not to use too many threads for smaller matrices
-            let size_factor = m * k + k * n;
-            let thread_factor = 1 << 16;
-            // pure guesswork in terms of what the default should be
-            let arch_factor = if cfg!(any(target_arch="arm", target_arch="aarch64")) {
-                20
-            } else {
-                1
-            };
+            Self::new_impl(m, k, n, max_threads, K::mc())
+        }
+    }
 
-            // At the moment only a configuration of 1, 2, or 4 threads is supported.
-            //
-            // Prefer to split Loop 3 if only 2 threads are available, (because it was better in a
-            // square matrix benchmark).
-            let kmc = K::mc();
+    #[cfg(feature="threading")]
+    fn new_impl(m: usize, k: usize, n: usize, max_threads: usize, kmc: usize) -> Self {
+        // use a heuristic to try not to use too many threads for smaller matrices
+        let size_factor = m * k + k * n;
+        let thread_factor = 1 << 16;
+        // pure guesswork in terms of what the default should be
+        let arch_factor = if cfg!(any(target_arch="arm", target_arch="aarch64")) {
+            20
+        } else {
+            1
+        };
 
-            let matrix_max_threads = size_factor / (thread_factor / arch_factor);
-            let mut max_threads = max_threads.min(matrix_max_threads);
+        // At the moment only a configuration of 1, 2, or 4 threads is supported.
+        //
+        // Prefer to split Loop 3 if only 2 threads are available, (because it was better in a
+        // square matrix benchmark).
 
-            let loop3 = if max_threads >= 2 && m >= 3 * (kmc / 2) {
-                max_threads /= 2;
-                2
-            } else {
-                1
-            };
-            let loop2 = if max_threads >= 2 { 2 } else { 1 };
+        let matrix_max_threads = size_factor / (thread_factor / arch_factor);
+        let mut max_threads = max_threads.min(matrix_max_threads);
 
-            LoopThreadConfig {
-                loop3,
-                loop2,
-            }
+        let loop3 = if max_threads >= 2 && m >= 3 * (kmc / 2) {
+            max_threads /= 2;
+            2
+        } else {
+            1
+        };
+        let loop2 = if max_threads >= 2 { 2 } else { 1 };
+
+        LoopThreadConfig {
+            loop3,
+            loop2,
         }
     }
 

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -62,7 +62,7 @@ static REGISTRY: Lazy<Registry> = Lazy::new(|| {
                 1
             }
         }
-        _otherwise => 1,
+        _otherwise => num_cpus::get_physical(),
     };
 
     let tp = if threads <= 1 {

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -2,6 +2,8 @@
 /// Threading support functions and statics
 
 #[cfg(feature="threading")]
+use std::cmp::min;
+#[cfg(feature="threading")]
 use std::str::FromStr;
 #[cfg(feature="threading")]
 use once_cell::sync::Lazy;
@@ -12,7 +14,7 @@ pub use thread_tree::ThreadTree as ThreadPool;
 pub use thread_tree::ThreadTreeCtx as ThreadPoolCtx;
 
 use crate::kernel::GemmKernel;
-
+use crate::util::RangeChunk;
 
 /// Dummy threadpool
 #[cfg(not(feature="threading"))]
@@ -148,5 +150,118 @@ impl LoopThreadConfig {
     /// Number of packing buffers for A
     #[inline(always)]
     pub(crate) fn num_pack_a(&self) -> usize { self.loop3 as usize }
+}
+
+
+impl RangeChunk {
+    /// "Builder" method to create a RangeChunkParallel
+    pub(crate) fn parallel(self, nthreads: u8, pool: ThreadPoolCtx) -> RangeChunkParallel<fn()> {
+        fn nop() {}
+
+        RangeChunkParallel {
+            nthreads,
+            pool,
+            range: self,
+            thread_local: nop,
+        }
+    }
+}
+
+/// Intermediate struct for building the parallel execution of a range chunk.
+pub(crate) struct RangeChunkParallel<'a, G> {
+    range: RangeChunk,
+    nthreads: u8,
+    pool: ThreadPoolCtx<'a>,
+    thread_local: G,
+}
+
+impl<'a, G> RangeChunkParallel<'a, G> {
+    #[cfg(feature="threading")]
+    /// Set thread local setup function - called once per thread to setup thread local data.
+    pub(crate) fn thread_local<G2, R>(self, func: G2) -> RangeChunkParallel<'a, G2>
+        where G2: Fn(usize, usize) -> R + Sync
+    {
+        RangeChunkParallel {
+            nthreads: self.nthreads,
+            pool: self.pool,
+            thread_local: func,
+            range: self.range,
+        }
+    }
+
+    #[cfg(not(feature="threading"))]
+    /// Set thread local setup function - called once per thread to setup thread local data.
+    pub(crate) fn thread_local<G2, R>(self, func: G2) -> RangeChunkParallel<'a, G2>
+        where G2: FnOnce(usize, usize) -> R + Sync
+    {
+        RangeChunkParallel {
+            nthreads: self.nthreads,
+            pool: self.pool,
+            thread_local: func,
+            range: self.range,
+        }
+    }
+}
+
+#[cfg(not(feature="threading"))]
+impl<G, R> RangeChunkParallel<'_, G>
+    where G: FnOnce(usize, usize) -> R + Sync,
+{
+    pub(crate) fn for_each<F>(self, for_each: F)
+        where F: Fn(ThreadPoolCtx<'_>, &mut R, usize, usize) + Sync,
+    {
+        let mut local = (self.thread_local)(0, 1);
+        for (ln, chunk_size) in self.range {
+            for_each(self.pool, &mut local, ln, chunk_size)
+        }
+    }
+}
+
+
+#[cfg(feature="threading")]
+impl<G, R> RangeChunkParallel<'_, G>
+    where G: Fn(usize, usize) -> R + Sync,
+{
+    /// Execute loop iterations (parallel if enabled) using the given closure.
+    ///
+    /// The closure gets the following arguments for each iteration:
+    ///
+    /// - Thread pool context (used for child threads)
+    /// - Mutable reference to thread local data
+    /// - index of chunk (like RangeChunk)
+    /// - size of chunk (like RangeChunk)
+    pub(crate) fn for_each<F>(self, for_each: F)
+        where F: Fn(ThreadPoolCtx<'_>, &mut R, usize, usize) + Sync,
+    {
+        fn inner<F, G, R>(range: RangeChunk, index: usize, nthreads: usize, pool: ThreadPoolCtx<'_>,
+                          thread_local: G, for_each: F)
+            where G: Fn(usize, usize) -> R + Sync,
+                  F: Fn(ThreadPoolCtx<'_>, &mut R, usize, usize) + Sync
+        {
+            let mut local = thread_local(index, nthreads);
+            for (ln, chunk_size) in range.part(index, nthreads) {
+                for_each(pool, &mut local, ln, chunk_size)
+            }
+        }
+
+        debug_assert!(self.nthreads <= 4, "this method does not support nthreads > 4, got {}",
+                      self.nthreads);
+        let pool = self.pool;
+        let range = self.range;
+        let for_each = &for_each;
+        let local = &self.thread_local;
+        let nthreads = min(self.nthreads as usize, 4);
+        let f = move |ctx: ThreadPoolCtx<'_>, i| inner(range, i, nthreads, ctx, local, for_each);
+        if nthreads >= 4 {
+            pool.join4(&f);
+        } else if nthreads >= 3 {
+            pool.join3l(&f);
+        } else if nthreads >= 2 {
+            pool.join(|ctx| f(ctx, 0), |ctx| f(ctx, 1));
+        } else {
+            f(pool, 0)
+        }
+    }
+
 }
 

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -99,5 +99,9 @@ impl LoopThreadConfig {
             }
         }
     }
+
+    /// Number of packing buffers for A
+    #[inline(always)]
+    pub(crate) fn num_pack_a(&self) -> usize { self.loop3 as usize }
 }
 

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -1,0 +1,103 @@
+///
+/// Threading support functions and statics
+
+#[cfg(feature="threading")]
+use std::str::FromStr;
+#[cfg(feature="threading")]
+use once_cell::sync::Lazy;
+
+#[cfg(feature="threading")]
+pub use thread_tree::ThreadTree as ThreadPool;
+#[cfg(feature="threading")]
+pub use thread_tree::ThreadTreeCtx as ThreadPoolCtx;
+
+/// Dummy threadpool
+#[cfg(not(feature="threading"))]
+pub(crate) struct ThreadPool;
+
+#[cfg(not(feature="threading"))]
+pub type ThreadPoolCtx<'a> = &'a ();
+
+#[cfg(not(feature="threading"))]
+impl ThreadPool {
+    /// Get top dummy thread pool context
+    pub(crate) fn top(&self) -> ThreadPoolCtx<'_> { &() }
+}
+
+use crate::kernel::GemmKernel;
+
+#[cfg(not(feature="threading"))]
+pub(crate) const NTHREADS: &'static usize = &1;
+
+#[cfg(feature="threading")]
+pub(crate) static NTHREADS: Lazy<usize> = Lazy::new(|| {
+    let var = ::std::env::var("MATMUL_NUM_THREADS").ok();
+    let threads = match var {
+        Some(s) if !s.is_empty() => {
+            if let Ok(nt) = usize::from_str(&s) {
+                1.max(nt)
+            } else {
+                eprintln!("Failed to parse MATMUL_NUM_THREADS");
+                1
+            }
+        }
+        _otherwise => 1,
+    };
+    threads
+});
+
+
+#[cfg(not(feature="threading"))]
+pub(crate) const THREADPOOL: ThreadPool = ThreadPool;
+
+#[cfg(feature="threading")]
+pub(crate) static THREADPOOL: Lazy<Box<ThreadPool>> = Lazy::new(|| {
+    let threads = *NTHREADS;
+    if threads <= 1 {
+        Box::new(ThreadPool::new_level0())
+    } else if threads <= 3 {
+        ThreadPool::new_with_level(1)
+    } else {
+        ThreadPool::new_with_level(2)
+    }
+});
+
+/// Describe how many threads we use in each loop
+#[derive(Copy, Clone)]
+pub(crate) struct LoopThreadConfig {
+    /// Loop 3 threads
+    pub(crate) loop3: u8,
+    /// Loop 2 threads
+    pub(crate) loop2: u8,
+}
+
+impl LoopThreadConfig {
+    /// Decide how many threads to use in each loop
+    pub(crate) fn new<K>(m: usize, k: usize, n: usize, max_threads: usize) -> Self
+        where K: GemmKernel
+    {
+        #[cfg(not(feature="threading"))]
+        let _ = (m, k, n, max_threads); // used
+        #[cfg(not(feature="threading"))]
+        return LoopThreadConfig { loop3: 1, loop2: 1 };
+
+        #[cfg(feature="threading")]
+        {
+            // At the moment only a configuration of 1, 2, or 4 threads is supported.
+            //
+            // Prefer to split Loop 3 if only 2 threads are available, (because it was better in a
+            // square matrix benchmark).
+            let kmc = K::mc();
+
+            let use_threads = max_threads > 1 && (m > 32 || k > 32 || n > 32);
+            let loop3 = if use_threads && max_threads >= 2 && m >= 3 * (kmc/2) { 2 } else { 1 };
+            let loop2 = if use_threads && (max_threads >= 4 || loop3 == 1) { 2 } else { 1 };
+
+            LoopThreadConfig {
+                loop3,
+                loop2,
+            }
+        }
+    }
+}
+

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,8 +8,6 @@
 
 use core::cmp::min;
 
-use crate::threading::ThreadPoolCtx;
-
 #[derive(Copy, Clone)]
 pub struct RangeChunk { i: usize, n: usize, chunk: usize }
 
@@ -47,138 +45,27 @@ pub fn round_up_to(x: usize, multiple_of: usize) -> usize {
     d * multiple_of
 }
 
-#[cfg(feature="threading")]
-/// Create an iterator that splits `n` in chunks of size `chunk`;
-/// the last item can be an uneven chunk.
-///
-/// And splits the iterator in `total` parts and only iterates the `index`th part of it
-pub fn range_chunk_part(n: usize, chunk: usize, index: usize, total: usize) -> RangeChunk {
-    debug_assert_ne!(total, 0);
-
-    // round up
-    let mut nchunks = n / chunk;
-    nchunks += (n % chunk != 0) as usize;
-
-    // chunks per thread
-    // round up
-    let mut chunks_per = nchunks / total;
-    chunks_per += (nchunks % total != 0) as usize;
-
-    let i = chunks_per * index;
-    let nn = min(n, (i + chunks_per) * chunk).saturating_sub(i * chunk);
-
-    RangeChunk { i, n: nn, chunk }
-}
-
 impl RangeChunk {
-    /// "Builder" method to create a RangeChunkParallel
-    pub(crate) fn parallel(self, nthreads: u8, pool: ThreadPoolCtx) -> RangeChunkParallel<fn()> {
-        fn nop() {}
-
-        RangeChunkParallel {
-            nthreads,
-            pool,
-            range: self,
-            thread_local: nop,
-        }
-    }
-}
-
-/// Intermediate struct for building the parallel execution of a range chunk.
-pub(crate) struct RangeChunkParallel<'a, G> {
-    range: RangeChunk,
-    nthreads: u8,
-    pool: ThreadPoolCtx<'a>,
-    thread_local: G,
-}
-
-impl<'a, G> RangeChunkParallel<'a, G> {
     #[cfg(feature="threading")]
-    /// Set thread local setup function - called once per thread to setup thread local data.
-    pub(crate) fn thread_local<G2, R>(self, func: G2) -> RangeChunkParallel<'a, G2>
-        where G2: Fn(usize, usize) -> R + Sync
-    {
-        RangeChunkParallel {
-            nthreads: self.nthreads,
-            pool: self.pool,
-            thread_local: func,
-            range: self.range,
-        }
-    }
+    /// Split the iterator in `total` parts and only iterate the `index`th part of it.
+    /// The iterator must not have started when this is called.
+    pub(crate) fn part(self, index: usize, total: usize) -> Self {
+        debug_assert_eq!(self.i, 0, "range must be uniterated");
+        debug_assert_ne!(total, 0);
+        let (n, chunk) = (self.n, self.chunk);
 
-    #[cfg(not(feature="threading"))]
-    /// Set thread local setup function - called once per thread to setup thread local data.
-    pub(crate) fn thread_local<G2, R>(self, func: G2) -> RangeChunkParallel<'a, G2>
-        where G2: FnOnce(usize, usize) -> R + Sync
-    {
-        RangeChunkParallel {
-            nthreads: self.nthreads,
-            pool: self.pool,
-            thread_local: func,
-            range: self.range,
-        }
+        // round up
+        let mut nchunks = n / chunk;
+        nchunks += (n % chunk != 0) as usize;
+
+        // chunks per thread
+        // round up
+        let mut chunks_per = nchunks / total;
+        chunks_per += (nchunks % total != 0) as usize;
+
+        let i = chunks_per * index;
+        let nn = min(n, (i + chunks_per) * chunk).saturating_sub(i * chunk);
+
+        RangeChunk { i, n: nn, chunk }
     }
 }
-
-#[cfg(not(feature="threading"))]
-impl<G, R> RangeChunkParallel<'_, G>
-    where G: FnOnce(usize, usize) -> R + Sync,
-{
-    pub(crate) fn for_each<F>(self, for_each: F)
-        where F: Fn(ThreadPoolCtx<'_>, &mut R, usize, usize) + Sync,
-    {
-        let mut local = (self.thread_local)(0, 1);
-        for (ln, chunk_size) in self.range {
-            for_each(self.pool, &mut local, ln, chunk_size)
-        }
-    }
-}
-
-
-#[cfg(feature="threading")]
-impl<G, R> RangeChunkParallel<'_, G>
-    where G: Fn(usize, usize) -> R + Sync,
-{
-    /// Execute loop iterations (parallel if enabled) using the given closure.
-    ///
-    /// The closure gets the following arguments for each iteration:
-    ///
-    /// - Thread pool context (used for child threads)
-    /// - Mutable reference to thread local data
-    /// - index of chunk (like RangeChunk)
-    /// - size of chunk (like RangeChunk)
-    pub(crate) fn for_each<F>(self, for_each: F)
-        where F: Fn(ThreadPoolCtx<'_>, &mut R, usize, usize) + Sync,
-    {
-        fn inner<F, G, R>(range: RangeChunk, index: usize, nthreads: usize, pool: ThreadPoolCtx<'_>,
-                          thread_local: G, for_each: F)
-            where G: Fn(usize, usize) -> R + Sync,
-                  F: Fn(ThreadPoolCtx<'_>, &mut R, usize, usize) + Sync
-        {
-            let mut local = thread_local(index, nthreads);
-            for (ln, chunk_size) in range_chunk_part(range.n, range.chunk, index, nthreads) {
-                for_each(pool, &mut local, ln, chunk_size)
-            }
-        }
-
-        debug_assert!(self.nthreads <= 4, "this method does not support nthreads > 4, got {}",
-                      self.nthreads);
-        let pool = self.pool;
-        let range = self.range;
-        let for_each = &for_each;
-        let local = &self.thread_local;
-        let nthreads = min(self.nthreads as usize, 4);
-        let f = move |ctx: ThreadPoolCtx<'_>, i| inner(range, i, nthreads, ctx, local, for_each);
-        if nthreads >= 4 {
-            pool.join4(&f);
-        } else if nthreads >= 3 {
-            pool.join3l(&f);
-        } else if nthreads >= 2 {
-            pool.join(|ctx| f(ctx, 0), |ctx| f(ctx, 1));
-        } else {
-            f(pool, 0)
-        }
-    }
-
-}
-

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,6 +8,7 @@
 
 use core::cmp::min;
 
+#[derive(Copy, Clone)]
 pub struct RangeChunk { i: usize, n: usize, chunk: usize }
 
 /// Create an iterator that splits `n` in chunks of size `chunk`;
@@ -42,4 +43,26 @@ pub fn round_up_to(x: usize, multiple_of: usize) -> usize {
     let (mut d, r) = (x / multiple_of, x % multiple_of);
     if r > 0 { d += 1; }
     d * multiple_of
+}
+
+/// Create an iterator that splits `n` in chunks of size `chunk`;
+/// the last item can be an uneven chunk.
+///
+/// And splits the iterator in `total` parts and only iterates the `index`th part of it
+pub fn range_chunk_part(n: usize, chunk: usize, index: usize, total: usize) -> RangeChunk {
+    debug_assert_ne!(total, 0);
+
+    // round up
+    let mut nchunks = n / chunk;
+    nchunks += (n % chunk != 0) as usize;
+
+    // chunks per thread
+    // round up
+    let mut chunks_per = nchunks / total;
+    chunks_per += (nchunks % total != 0) as usize;
+
+    let i = chunks_per * index;
+    let nn = min(n, (i + chunks_per) * chunk).saturating_sub(i * chunk);
+
+    RangeChunk { i, n: nn, chunk }
 }

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -12,7 +12,7 @@ pub(crate) struct AvxMulAdd;
 
 pub(crate) trait SMultiplyAdd {
     const IS_FUSED: bool;
-    unsafe fn multiply_add(__m256, __m256, __m256) -> __m256;
+    unsafe fn multiply_add(a: __m256, b: __m256, c: __m256) -> __m256;
 }
 
 impl SMultiplyAdd for AvxMulAdd {
@@ -33,7 +33,7 @@ impl SMultiplyAdd for FusedMulAdd {
 
 pub(crate) trait DMultiplyAdd {
     const IS_FUSED: bool;
-    unsafe fn multiply_add(__m256d, __m256d, __m256d) -> __m256d;
+    unsafe fn multiply_add(a: __m256d, b: __m256d, c: __m256d) -> __m256d;
 }
 
 impl DMultiplyAdd for AvxMulAdd {


### PR DESCRIPTION
Use a tree-structured thread pool and introduce a "minimum viable product" implementation of multithreading.

The tree structure thread pool allows us to get around the slowdown from worker contention that we have seen in other solutions (in experiments with rayon and other thread pools).

More or less, other thread pools show some overhead due to contention when delivering work items to the pool, for example when having a too small matrix with just two work items, the four pools in the thread pool would use extra cpu time just looking for work. The tree structure thread pool avoids this.

Now we instead have this structure:

```rust
// Every node has two fields:
// - sender: A channel sender to pass jobs to its right child
// - child: An array of the two child nodes.
//
// The root node has a sender that can pass jobs to its right child (2).
// Jobs in child (1) are simply achieved by running them in the root itself. This continues recursively.
//
// In the following diagram, all the nodes of a 2-level tree. It has four leaves and we have spawned 3 threads
// for this tree - the nodes not in parentheses have their own thread.
//
//          (root)
//     (1)           2
// (1.1)  1.2   (2.1)  2.2
//                            
```

Environment variable MATMUL_NUM_THREADS decides how many threads will be used.
The default is 1 (no threading).

The matrix-matrix multiplication has five loops, and loops 5, 3, 2, and 1 are amenable to "easy" parallelization,
and the reason for 4 not being amenable is marked with a comment in the code.

This PR implements parallelization of loops 3 and 2. The loops are nested so using a parallelism of 2 in each of the places gives a total fanout of 2 x 2 = 4 threads.

The direction for future expansion is supporting 1-4 thread fanout per loop, and support parallelization of loop 5. This makes threading configurations like for example 1 x 3 x 2 = 6 threads and 2 x 4 x 2 = 16 threads possible up to a maximum of 4 x 4 x 4 = 64 threads. The major missing piece for going through with that is just finding the appropriate heuristic for thread fanout per loop.

New dependencies for the threading feature:

- **thread-tree**: New bare bones hierarchical tree-structured thread pool developed for this use case
- **once_cell**: Same usecase as lazy_static, for storing the thread pool and threading configuration in a global variable.
- **num_cpus**: Get number of physical cpus for default thread count. Used for a good default experience. Same dep as rayon and common thread pools.


## Overhead

The threading feature itself has small but measurable overhead.
When threads are used thread communication has some overhead but it seems to be comparable with other similar libraries (BLAS impls). Matrix packing is only partially parallel - in this PR, packing B is sequential (loop 4) and packing A is parallelized by the fanout of loop 3.

## Rust Version

Update MSRV to Rust 1.41.1 (Randomly picked as debian's current version and reasonably recent)
Next version of matrixmultiply will not consider Rust updates to be breaking changes (this follows the community).