### PR TITLE
Align mask buffer pointer manually

### DIFF
--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -240,10 +240,14 @@ unsafe fn gemm_loop<K>(
 // set up buffer for masked (redirected output of) kernel
 const KERNEL_MAX_SIZE: usize = 8 * 8 * 4;
 const KERNEL_MAX_ALIGN: usize = 32;
+const MASK_BUF_SIZE: usize = KERNEL_MAX_SIZE + KERNEL_MAX_ALIGN - 1;
 
+// Pointers into buffer will be manually aligned anyway, due to
+// bugs we have seen on certain platforms (macos) that look like
+// we don't get aligned allocations out of TLS (?).
 #[repr(align(32))]
 struct MaskBuffer {
-    buffer: [u8; KERNEL_MAX_SIZE],
+    buffer: [u8; MASK_BUF_SIZE],
 }
 
 // Use thread local if we can; this is faster even in the single threaded case because
@@ -251,7 +255,7 @@ struct MaskBuffer {
 #[cfg(feature = "std")]
 thread_local! {
     static MASK_BUF: UnsafeCell<MaskBuffer> =
-        UnsafeCell::new(MaskBuffer { buffer: [0; KERNEL_MAX_SIZE] });
+        UnsafeCell::new(MaskBuffer { buffer: [0; MASK_BUF_SIZE] });
 }
 
 /// Loops 1 and 2 around the µ-kernel
@@ -272,16 +276,16 @@ unsafe fn gemm_packed<K>(nc: usize, kc: usize, mc: usize,
     let mr = K::MR;
     let nr = K::NR;
     // check for the mask buffer that fits 8 x 8 f32 and 8 x 4 f64 kernels and alignment
-    assert!(mr * nr * size_of::<K::Elem>() <= KERNEL_MAX_SIZE && K::align_to() <= KERNEL_MAX_ALIGN);
+    assert!(mr * nr * size_of::<K::Elem>() <= MASK_BUF_SIZE && K::align_to() <= KERNEL_MAX_ALIGN);
 
     #[cfg(not(feature = "std"))]
-    let mut mask_buf = MaskBuffer { buffer: [0; KERNEL_MAX_SIZE] };
+    let mut mask_buf = MaskBuffer { buffer: [0; MASK_BUF_SIZE] };
 
     // LOOP 2: through micropanels in packed `b` (B~, C)
     range_chunk(nc, nr)
         .parallel(thread_config.loop2, tp)
         .thread_local(|_i, _nt| {
-            let ptr;
+            let mut ptr;
             #[cfg(not(feature = "std"))]
             {
                 debug_assert_eq!(_nt, 1);
@@ -291,7 +295,7 @@ unsafe fn gemm_packed<K>(nc: usize, kc: usize, mc: usize,
             {
                 ptr = MASK_BUF.with(|buf| (*buf.get()).buffer.as_mut_ptr());
             }
-            debug_assert_eq!(ptr as usize % KERNEL_MAX_ALIGN, 0);
+            ptr = align_ptr(K::align_to(), ptr);
             slice::from_raw_parts_mut(ptr as *mut K::Elem, KERNEL_MAX_SIZE / size_of::<K::Elem>())
         })
         .for_each(move |_tp, mask_buf, l2, nr_| {
@@ -350,6 +354,19 @@ unsafe fn make_packing_buffer<K>(m: usize, k: usize, n: usize, na: usize) -> (Al
              m,k,n, na);
 
     (Alloc::new(nelem, K::align_to()), apack_size)
+}
+
+/// offset the ptr forwards to align to a specific byte count
+/// Safety: align_to must be a power of two and ptr valid for the pointer arithmetic
+#[inline]
+unsafe fn align_ptr<T>(align_to: usize, mut ptr: *mut T) -> *mut T {
+    if align_to != 0 {
+        let cur_align = ptr as usize % align_to;
+        if cur_align != 0 {
+            ptr = ptr.offset(((align_to - cur_align) / size_of::<T>()) as isize);
+        }
+    }
+    ptr
 }
 
 /// Pack matrix into `pack`


### PR DESCRIPTION
New in 0.3.0 was that we are using TLS for the masking buffer,
and using `#[repr(align(32))]` to 32-byte align it. It seems one
of those choices didn't work out.

So we manually align the pointer into the buffer anyway, due to
bugs we have seen on certain platforms (macos) that look like
we don't get aligned allocations out of TLS (?).

Fixes #55 (Hopefully)

This removes the debug assertion we are hitting in #55, because
here we make the alignment happen.

Halfway reverts previous commit 2ddd0ba04b8ff0f2f82fd3cf6459955fdd536be5
