### PR TITLE
Add experimental support for complex: cgemm/zgemm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,11 @@ jobs:
           - rust: 1.41.1  # MSRV
             experimental: false
             target: x86_64-unknown-linux-gnu
+            features: cgemm
           - rust: stable
             experimental: false
             target: x86_64-unknown-linux-gnu
-            features: threading
+            features: threading cgemm
             test_examples: yes
           - rust: nightly
             experimental: false
@@ -32,11 +33,12 @@ jobs:
             mmtest_feature: avx
           - rust: nightly
             target: x86_64-unknown-linux-gnu
-            features: threading
+            features: threading cgemm
             mmtest_feature: fma
             experimental: false
           - rust: nightly
             target: i686-unknown-linux-gnu
+            features: cgemm
             install_deps: |
               sudo apt-get update
               sudo apt-get install -y gcc-multilib

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ itertools = "0.8"
 [features]
 default = ["std"]
 
+# support for complex f32, complex f64
+cgemm = []
+
 threading = ["thread-tree", "std", "once_cell", "num_cpus"]
 std = []
 
@@ -55,3 +58,7 @@ debug = true
 no-dev-version = true
 tag-name = "{{version}}"
 
+[package.metadata.docs.rs]
+features = ["cgemm"]
+# defines the configuration attribute `docsrs`
+rustdoc-args = ["--cfg", "docsrs"]

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,13 @@ Development Goals
 - Small code footprint and fast compilation
 - We are not reimplementing BLAS.
 
+Benchmarks
+----------
+
+- ``cargo bench`` is useful for special cases and small matrices
+- The best gemm and threading benchmark is is ``examples/benchmarks.rs`` which supports custom sizes,
+  some configuration, and csv output.
+
 Blog Posts About This Crate
 ---------------------------
 

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -52,6 +52,15 @@ enum UseType {
 }
 
 impl UseType {
+    fn type_name(self) -> &'static str {
+        use UseType::*;
+        match self {
+            F32 => "f32",
+            F64 => "f64",
+            C32 => "c32",
+            C64 => "c64",
+        }
+    }
     fn flop_factor(self) -> f64 {
         match self {
             // estimate one multiply and one addition
@@ -347,7 +356,7 @@ fn test_matrix<F>(m: usize, k: usize, n: usize, layouts: [Layout; 3], use_csv: b
     //println!("{:#?}", statistics);
     let gflop = use_type.flop_factor() * (m as f64 * n as f64 * k as f64) / statistics.average as f64;
     if !use_csv {
-        print!("{}×{}×{} {:?} {} .. {} ns", m, k, n, layouts, std::any::type_name::<F>(),
+        print!("{}×{}×{} {:?} {} .. {} ns", m, k, n, layouts, use_type.type_name(),
                fmt_thousands_sep(statistics.average, " "));
         print!(" [minimum: {} ns .. median {} ns .. sample count {}]", 
                fmt_thousands_sep(statistics.minimum, " "),
@@ -359,7 +368,7 @@ fn test_matrix<F>(m: usize, k: usize, n: usize, layouts: [Layout; 3], use_csv: b
     } else {
         print!("{},{},{},", m, k, n);
         print!("{:?},", layouts.iter().format(""));
-        print!("{},", std::any::type_name::<F>());
+        print!("{},", use_type.type_name());
         print!("{},{},{},{},", statistics.average, statistics.minimum, statistics.median,
                statistics.samples.len());
         print!("{}", gflop);

--- a/src/archparam.rs
+++ b/src/archparam.rs
@@ -8,7 +8,7 @@
 //! architechture specific parameters
 
 /// Columns in C, B that we handle at a time. (5th loop)
-/// 
+///
 /// Cuts B into B0, B1, .. Bj, .. B_NC
 pub const S_NC: usize = 1024;
 
@@ -33,7 +33,7 @@ pub const S_KC: usize = 256;
 pub const S_MC: usize = 64;
 
 /// Columns in C, B that we handle at a time. (5th loop)
-/// 
+///
 /// Cuts B into B0, B1, .. Bj, .. B_NC
 pub const D_NC: usize = 1024;
 
@@ -56,3 +56,59 @@ pub const D_KC: usize = 256;
 ///
 /// Size of A~ is KC x MC
 pub const D_MC: usize = 64;
+
+#[cfg(feature = "cgemm")]
+/// Columns in C, B that we handle at a time. (5th loop)
+///
+/// Cuts B into B0, B1, .. Bj, .. B_NC
+pub const C_NC: usize = S_NC / 2;
+
+#[cfg(feature = "cgemm")]
+/// Rows of Bj at a time (4th loop)
+///
+/// Columns of A at a time.
+///
+/// Cuts A into Ap
+///
+/// Cuts Bj into Bp, which is packed into B~.
+///
+/// Size of B~ is NC x KC
+pub const C_KC: usize = S_KC;
+
+#[cfg(feature = "cgemm")]
+/// Rows of Ap at a time. (3rd loop)
+///
+/// Cuts Ap into A0, A1, .., Ai, .. A_MC
+///
+/// Ai is packed into A~.
+///
+/// Size of A~ is KC x MC
+pub const C_MC: usize = S_MC / 2;
+
+#[cfg(feature = "cgemm")]
+/// Columns in C, B that we handle at a time. (5th loop)
+///
+/// Cuts B into B0, B1, .. Bj, .. B_NC
+pub const Z_NC: usize = D_NC / 2;
+
+#[cfg(feature = "cgemm")]
+/// Rows of Bj at a time (4th loop)
+///
+/// Columns of A at a time.
+///
+/// Cuts A into Ap
+///
+/// Cuts Bj into Bp, which is packed into B~.
+///
+/// Size of B~ is NC x KC
+pub const Z_KC: usize = D_KC;
+
+#[cfg(feature = "cgemm")]
+/// Rows of Ap at a time. (3rd loop)
+///
+/// Cuts Ap into A0, A1, .., Ai, .. A_MC
+///
+/// Ai is packed into A~.
+///
+/// Size of A~ is KC x MC
+pub const Z_MC: usize = D_MC / 2;

--- a/src/cgemm_common.rs
+++ b/src/cgemm_common.rs
@@ -1,0 +1,67 @@
+// Copyright 2021 Ulrik Sverdrup "bluss"
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// kernel fallback impl macro
+// Depends on a couple of macro and function defitions to be in scope - loop_m/_n, at, etc.
+macro_rules! kernel_fallback_impl_complex {
+    ([$($attr:meta)*] $name:ident, $elem_ty:ty, $real_ty:ty, $mr:expr, $nr:expr, $unroll:tt) => {
+    $(#[$attr])*
+    unsafe fn $name(k: usize, alpha: $elem_ty, a: *const $elem_ty, b: *const $elem_ty,
+                    beta: $elem_ty, c: *mut $elem_ty, rsc: isize, csc: isize)
+    {
+        const MR: usize = $mr;
+        const NR: usize = $nr;
+
+        debug_assert_eq!(beta, <$elem_ty>::zero(), "Beta must be 0 or is not masked");
+
+        let mut pp  = [<$real_ty>::zero(); MR];
+        let mut qq  = [<$real_ty>::zero(); MR];
+        let mut rr  = [<$real_ty>::zero(); NR];
+        let mut ss  = [<$real_ty>::zero(); NR];
+
+        let mut ab: [[$elem_ty; NR]; MR] = [[<$elem_ty>::zero(); NR]; MR];
+        let mut a = a;
+        let mut b = b;
+
+        // Compute A B into ab[i][j]
+        unroll_by!($unroll => k, {
+            // We set
+            //
+            // P + Q i = A
+            // R + S i = B
+            loop_m!(i, pp[i] = at(a, i)[0]);
+            loop_m!(i, qq[i] = at(a, i)[1]);
+            loop_n!(i, rr[i] = at(b, i)[0]);
+            loop_n!(i, ss[i] = at(b, i)[1]);
+
+            loop_m!(i, loop_n!(j, {
+                ab[i][j][0] += pp[i] * rr[j];
+            }));
+            loop_m!(i, loop_n!(j, {
+                ab[i][j][1] += pp[i] * ss[j];
+            }));
+            loop_m!(i, loop_n!(j, {
+                ab[i][j][0] -= qq[i] * ss[j];
+            }));
+            loop_m!(i, loop_n!(j, {
+                ab[i][j][1] += qq[i] * rr[j];
+            }));
+
+            a = a.offset(MR as isize);
+            b = b.offset(NR as isize);
+        });
+
+        macro_rules! c {
+            ($i:expr, $j:expr) => (c.offset(rsc * $i as isize + csc * $j as isize));
+        }
+
+        // set C = α A B
+        loop_n!(j, loop_m!(i, *c![i, j] = mul(alpha, ab[i][j])));
+    }
+    };
+}

--- a/src/cgemm_kernel.rs
+++ b/src/cgemm_kernel.rs
@@ -10,7 +10,8 @@ use crate::kernel::GemmKernel;
 use crate::kernel::GemmSelect;
 use crate::kernel::{U2, U4, c32, Element, c32_mul as mul};
 
-
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+struct KernelFma;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 struct KernelSse2;
 struct KernelFallback;
@@ -28,7 +29,9 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
     // dispatch to specific compiled versions
     #[cfg(any(target_arch="x86", target_arch="x86_64"))]
     {
-        if is_x86_feature_detected_!("sse2") {
+        if is_x86_feature_detected_!("fma") {
+            return selector.select(KernelFma);
+        } else if is_x86_feature_detected_!("sse2") {
             return selector.select(KernelSse2);
         }
     }
@@ -38,6 +41,31 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
 macro_rules! loop_m { ($i:ident, $e:expr) => { loop4!($i, $e) }; }
 macro_rules! loop_n { ($j:ident, $e:expr) => { loop2!($j, $e) }; }
 
+
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+impl GemmKernel for KernelFma {
+    type Elem = T;
+
+    type MRTy = <KernelFallback as GemmKernel>::MRTy;
+    type NRTy = <KernelFallback as GemmKernel>::NRTy;
+
+    #[inline(always)]
+    fn align_to() -> usize { 16 }
+
+    #[inline(always)]
+    fn always_masked() -> bool { KernelFallback::always_masked() }
+
+    #[inline(always)]
+    unsafe fn kernel(
+        k: usize,
+        alpha: T,
+        a: *const T,
+        b: *const T,
+        beta: T,
+        c: *mut T, rsc: isize, csc: isize) {
+        kernel_target_fma(k, alpha, a, b, beta, c, rsc, csc)
+    }
+}
 
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 impl GemmKernel for KernelSse2 {
@@ -86,6 +114,12 @@ impl GemmKernel for KernelFallback {
         c: *mut T, rsc: isize, csc: isize) {
         kernel_fallback_impl(k, alpha, a, b, beta, c, rsc, csc)
     }
+}
+
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+kernel_fallback_impl_complex! {
+    // instantiate fma separately to use an unroll count that works better here
+    [inline target_feature(enable="fma")] kernel_target_fma, T, TReal, KernelFallback::MR, KernelFallback::NR, 1
 }
 
 #[inline]
@@ -184,6 +218,7 @@ mod tests {
         }
 
         test_arch_kernels_x86! {
+            "fma", fma, KernelFma,
             "sse2", sse2, KernelSse2
         }
 

--- a/src/cgemm_kernel.rs
+++ b/src/cgemm_kernel.rs
@@ -9,6 +9,7 @@
 use crate::kernel::GemmKernel;
 use crate::kernel::GemmSelect;
 use crate::kernel::{U2, U4, c32, Element, c32_mul as mul};
+use crate::archparam;
 
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 struct KernelFma;
@@ -56,6 +57,13 @@ impl GemmKernel for KernelFma {
     fn always_masked() -> bool { KernelFallback::always_masked() }
 
     #[inline(always)]
+    fn nc() -> usize { archparam::C_NC }
+    #[inline(always)]
+    fn kc() -> usize { archparam::C_KC }
+    #[inline(always)]
+    fn mc() -> usize { archparam::C_MC }
+
+    #[inline(always)]
     unsafe fn kernel(
         k: usize,
         alpha: T,
@@ -81,6 +89,13 @@ impl GemmKernel for KernelSse2 {
     fn always_masked() -> bool { KernelFallback::always_masked() }
 
     #[inline(always)]
+    fn nc() -> usize { archparam::C_NC }
+    #[inline(always)]
+    fn kc() -> usize { archparam::C_KC }
+    #[inline(always)]
+    fn mc() -> usize { archparam::C_MC }
+
+    #[inline(always)]
     unsafe fn kernel(
         k: usize,
         alpha: T,
@@ -103,6 +118,13 @@ impl GemmKernel for KernelFallback {
 
     #[inline(always)]
     fn always_masked() -> bool { true }
+
+    #[inline(always)]
+    fn nc() -> usize { archparam::C_NC }
+    #[inline(always)]
+    fn kc() -> usize { archparam::C_KC }
+    #[inline(always)]
+    fn mc() -> usize { archparam::C_MC }
 
     #[inline(always)]
     unsafe fn kernel(

--- a/src/cgemm_kernel.rs
+++ b/src/cgemm_kernel.rs
@@ -1,0 +1,236 @@
+// Copyright 2016 - 2021 Ulrik Sverdrup "bluss"
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::kernel::GemmKernel;
+use crate::kernel::GemmSelect;
+use crate::kernel::{U2, U4, c32, Element, c32_mul as mul};
+
+
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+struct KernelSse2;
+struct KernelFallback;
+
+type T = c32;
+
+/// Detect which implementation to use and select it using the selector's
+/// .select(Kernel) method.
+///
+/// This function is called one or more times during a whole program's
+/// execution, it may be called for each gemm kernel invocation or fewer times.
+#[inline]
+pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
+    // dispatch to specific compiled versions
+    #[cfg(any(target_arch="x86", target_arch="x86_64"))]
+    {
+        if is_x86_feature_detected_!("sse2") {
+            return selector.select(KernelSse2);
+        }
+    }
+    return selector.select(KernelFallback);
+}
+
+#[cfg(all(test, any(target_arch="x86", target_arch="x86_64")))]
+macro_rules! loop_m { ($i:ident, $e:expr) => { loop4!($i, $e) }; }
+#[cfg(test)]
+macro_rules! loop_n { ($j:ident, $e:expr) => { loop2!($j, $e) }; }
+
+
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+impl GemmKernel for KernelSse2 {
+    type Elem = T;
+
+    type MRTy = <KernelFallback as GemmKernel>::MRTy;
+    type NRTy = <KernelFallback as GemmKernel>::NRTy;
+
+    #[inline(always)]
+    fn align_to() -> usize { 16 }
+
+    #[inline(always)]
+    fn always_masked() -> bool { KernelFallback::always_masked() }
+
+    #[inline(always)]
+    unsafe fn kernel(
+        k: usize,
+        alpha: T,
+        a: *const T,
+        b: *const T,
+        beta: T,
+        c: *mut T, rsc: isize, csc: isize) {
+        kernel_target_sse2(k, alpha, a, b, beta, c, rsc, csc)
+    }
+}
+
+impl GemmKernel for KernelFallback {
+    type Elem = T;
+
+    type MRTy = U4;
+    type NRTy = U2;
+
+    #[inline(always)]
+    fn align_to() -> usize { 0 }
+
+    #[inline(always)]
+    fn always_masked() -> bool { true }
+
+    #[inline(always)]
+    unsafe fn kernel(
+        k: usize,
+        alpha: T,
+        a: *const T,
+        b: *const T,
+        beta: T,
+        c: *mut T, rsc: isize, csc: isize) {
+        kernel_fallback_impl(k, alpha, a, b, beta, c, rsc, csc)
+    }
+}
+
+#[inline]
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+#[target_feature(enable="sse2")]
+unsafe fn kernel_target_sse2(k: usize, alpha: T, a: *const T, b: *const T,
+                             beta: T, c: *mut T, rsc: isize, csc: isize)
+{
+    kernel_fallback_impl(k, alpha, a, b, beta, c, rsc, csc)
+}
+
+#[inline]
+unsafe fn kernel_fallback_impl(k: usize, alpha: T, a: *const T, b: *const T,
+                               beta: T, c: *mut T, rsc: isize, csc: isize)
+{
+    const MR: usize = KernelFallback::MR;
+    const NR: usize = KernelFallback::NR;
+    let mut ab: [[T; NR]; MR] = [[T::zero(); NR]; MR];
+    let mut a = a;
+    let mut b = b;
+    debug_assert_eq!(beta, T::zero(), "Beta must be 0 or is not masked");
+
+    // Compute A B into ab[i][j]
+    unroll_by!(4 => k, {
+        loop4!(i, loop2!(j, ab[i][j].add_assign(mul(at(a, i), at(b, j)))));
+
+        a = a.offset(MR as isize);
+        b = b.offset(NR as isize);
+    });
+
+    macro_rules! c {
+        ($i:expr, $j:expr) => (c.offset(rsc * $i as isize + csc * $j as isize));
+    }
+
+    // set C = α A B
+    loop2!(j, loop4!(i, *c![i, j] = mul(alpha, ab[i][j])));
+}
+
+#[inline(always)]
+unsafe fn at(ptr: *const T, i: usize) -> T {
+    *ptr.offset(i as isize)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::vec;
+    use crate::aligned_alloc::Alloc;
+
+    fn aligned_alloc<K>(elt: K::Elem, n: usize) -> Alloc<K::Elem>
+        where K: GemmKernel,
+              K::Elem: Copy,
+    {
+        unsafe {
+            Alloc::new(n, K::align_to()).init_with(elt)
+        }
+    }
+
+    use super::T;
+
+    fn test_a_kernel<K: GemmKernel<Elem=T>>(_name: &str) {
+        const K: usize = 4;
+        let mr = K::MR;
+        let nr = K::NR;
+        let mut a = aligned_alloc::<K>(T::one(), mr * K);
+        let mut b = aligned_alloc::<K>(T::zero(), nr * K);
+        for (i, x) in a.iter_mut().enumerate() {
+            *x = [i as _, 1.];
+        }
+
+        for i in 0..Ord::min(K, nr) {
+            b[i + i * nr] = T::one(); 
+        }
+
+        let mut c = vec![T::zero(); mr * nr];
+        unsafe {
+            K::kernel(K, T::one(), &a[0], &b[0], T::zero(), &mut c[0], 1, mr as isize);
+            // col major C
+        }
+        let common_len = Ord::min(a.len(), c.len());
+        assert_eq!(&a[..common_len], &c[..common_len]);
+    }
+
+    #[test]
+    fn test_kernel_fallback_impl() {
+        test_a_kernel::<KernelFallback>("kernel");
+    }
+
+    #[cfg(any(target_arch="x86", target_arch="x86_64"))]
+    #[test]
+    fn test_loop_m_n() {
+        let mut m = [[0; KernelSse2::NR]; KernelSse2::MR];
+        loop_m!(i, loop_n!(j, m[i][j] += 1));
+        for arr in &m[..] {
+            for elt in &arr[..] {
+                assert_eq!(*elt, 1);
+            }
+        }
+    }
+
+    #[cfg(any(target_arch="x86", target_arch="x86_64"))]
+    mod test_arch_kernels {
+        use super::test_a_kernel;
+        use super::super::*;
+        #[cfg(feature = "std")]
+        use std::println;
+        macro_rules! test_arch_kernels_x86 {
+            ($($feature_name:tt, $name:ident, $kernel_ty:ty),*) => {
+                $(
+                #[test]
+                fn $name() {
+                    if is_x86_feature_detected_!($feature_name) {
+                        test_a_kernel::<$kernel_ty>(stringify!($name));
+                    } else {
+                        #[cfg(feature = "std")]
+                        println!("Skipping, host does not have feature: {:?}", $feature_name);
+                    }
+                }
+                )*
+            }
+        }
+
+        test_arch_kernels_x86! {
+            "sse2", sse2, KernelSse2
+        }
+
+        #[test]
+        fn ensure_target_features_tested() {
+            // If enabled, this test ensures that the requested feature actually
+            // was enabled on this configuration, so that it was tested.
+            let should_ensure_feature = !option_env!("MMTEST_ENSUREFEATURE")
+                                                    .unwrap_or("").is_empty();
+            if !should_ensure_feature {
+                // skip
+                return;
+            }
+            let feature_name = option_env!("MMTEST_FEATURE")
+                                          .expect("No MMTEST_FEATURE configured!");
+            let detected = match feature_name {
+                "sse2" => is_x86_feature_detected_!("sse2"),
+                _ => false,
+            };
+            assert!(detected, "Feature {:?} was not detected, so it could not be tested",
+                    feature_name);
+        }
+    }
+}

--- a/src/cgemm_kernel.rs
+++ b/src/cgemm_kernel.rs
@@ -16,6 +16,7 @@ struct KernelSse2;
 struct KernelFallback;
 
 type T = c32;
+type TReal = f32;
 
 /// Detect which implementation to use and select it using the selector's
 /// .select(Kernel) method.
@@ -34,9 +35,7 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
     return selector.select(KernelFallback);
 }
 
-#[cfg(all(test, any(target_arch="x86", target_arch="x86_64")))]
 macro_rules! loop_m { ($i:ident, $e:expr) => { loop4!($i, $e) }; }
-#[cfg(test)]
 macro_rules! loop_n { ($j:ident, $e:expr) => { loop2!($j, $e) }; }
 
 
@@ -98,32 +97,7 @@ unsafe fn kernel_target_sse2(k: usize, alpha: T, a: *const T, b: *const T,
     kernel_fallback_impl(k, alpha, a, b, beta, c, rsc, csc)
 }
 
-#[inline]
-unsafe fn kernel_fallback_impl(k: usize, alpha: T, a: *const T, b: *const T,
-                               beta: T, c: *mut T, rsc: isize, csc: isize)
-{
-    const MR: usize = KernelFallback::MR;
-    const NR: usize = KernelFallback::NR;
-    let mut ab: [[T; NR]; MR] = [[T::zero(); NR]; MR];
-    let mut a = a;
-    let mut b = b;
-    debug_assert_eq!(beta, T::zero(), "Beta must be 0 or is not masked");
-
-    // Compute A B into ab[i][j]
-    unroll_by!(4 => k, {
-        loop4!(i, loop2!(j, ab[i][j].add_assign(mul(at(a, i), at(b, j)))));
-
-        a = a.offset(MR as isize);
-        b = b.offset(NR as isize);
-    });
-
-    macro_rules! c {
-        ($i:expr, $j:expr) => (c.offset(rsc * $i as isize + csc * $j as isize));
-    }
-
-    // set C = α A B
-    loop2!(j, loop4!(i, *c![i, j] = mul(alpha, ab[i][j])));
-}
+kernel_fallback_impl_complex! { [inline(always)] kernel_fallback_impl, T, TReal, KernelFallback::MR, KernelFallback::NR, 2 }
 
 #[inline(always)]
 unsafe fn at(ptr: *const T, i: usize) -> T {

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -813,47 +813,15 @@ unsafe fn at(ptr: *const T, i: usize) -> T {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::aligned_alloc::Alloc;
-
-    fn aligned_alloc<K>(elt: K::Elem, n: usize) -> Alloc<K::Elem>
-        where K: GemmKernel,
-              K::Elem: Copy,
-    {
-        unsafe {
-            Alloc::new(n, K::align_to()).init_with(elt)
-        }
-    }
-
-    use super::T;
-
-    fn test_a_kernel<K: GemmKernel<Elem=T>>(_name: &str) {
-        const K: usize = 4;
-        let mr = K::MR;
-        let nr = K::NR;
-        let mut a = aligned_alloc::<K>(1., mr * K);
-        let mut b = aligned_alloc::<K>(0., nr * K);
-        for (i, x) in a.iter_mut().enumerate() {
-            *x = i as _;
-        }
-
-        for i in 0..K {
-            b[i + i * nr] = 1.;
-        }
-        let mut c = vec![0.; mr * nr];
-        unsafe {
-            K::kernel(K, 1., &a[0], &b[0], 0., &mut c[0], 1, mr as isize);
-            // col major C
-        }
-        assert_eq!(&a[..], &c[..a.len()]);
-    }
+    use crate::kernel::test::test_a_kernel;
 
     #[test]
     fn test_kernel_fallback_impl() {
-        test_a_kernel::<KernelFallback>("kernel");
+        test_a_kernel::<KernelFallback, _>("kernel");
     }
 
-    #[test]
     #[cfg(any(target_arch="x86", target_arch="x86_64"))]
+    #[test]
     fn test_loop_m_n() {
         let mut m = [[0; 4]; KernelAvx::MR];
         loop_m!(i, loop4!(j, m[i][j] += 1));
@@ -876,7 +844,7 @@ mod tests {
                 #[test]
                 fn $name() {
                     if is_x86_feature_detected_!($feature_name) {
-                        test_a_kernel::<$kernel_ty>(stringify!($name));
+                        test_a_kernel::<$kernel_ty, _>(stringify!($name));
                     } else {
                         #[cfg(feature = "std")]
                         println!("Skipping, host does not have feature: {:?}", $feature_name);

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -868,7 +868,7 @@ mod tests {
     mod test_arch_kernels {
         use super::test_a_kernel;
         use super::super::*;
-        #[cfg(features = "std")]
+        #[cfg(feature = "std")]
         use std::println;
         macro_rules! test_arch_kernels_x86 {
             ($($feature_name:tt, $name:ident, $kernel_ty:ty),*) => {
@@ -878,7 +878,7 @@ mod tests {
                     if is_x86_feature_detected_!($feature_name) {
                         test_a_kernel::<$kernel_ty>(stringify!($name));
                     } else {
-                        #[cfg(features = "std")]
+                        #[cfg(feature = "std")]
                         println!("Skipping, host does not have feature: {:?}", $feature_name);
                     }
                 }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -9,7 +9,7 @@
 use core::ops::{AddAssign, MulAssign};
 
 /// General matrix multiply kernel
-pub trait GemmKernel {
+pub(crate) trait GemmKernel {
     type Elem: Element;
 
     /// Kernel rows
@@ -59,7 +59,7 @@ pub trait GemmKernel {
         c: *mut Self::Elem, rsc: isize, csc: isize);
 }
 
-pub trait Element : Copy + AddAssign + MulAssign + Send + Sync {
+pub(crate) trait Element : Copy + AddAssign + MulAssign + Send + Sync {
     fn zero() -> Self;
     fn one() -> Self;
     fn is_zero(&self) -> bool;
@@ -86,12 +86,12 @@ pub(crate) trait GemmSelect<T> {
 }
 
 
-pub trait ConstNum {
+pub(crate) trait ConstNum {
     const VALUE: usize;
 }
 
-pub struct U4;
-pub struct U8;
+pub(crate) struct U4;
+pub(crate) struct U8;
 
 impl ConstNum for U4 { const VALUE: usize = 4; }
 impl ConstNum for U8 { const VALUE: usize = 8; }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 - 2018 Ulrik Sverdrup "bluss"
+// Copyright 2016 - 2021 Ulrik Sverdrup "bluss"
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -7,6 +7,8 @@
 // except according to those terms.
 
 use core::ops::{AddAssign, MulAssign};
+
+use crate::archparam;
 
 /// General matrix multiply kernel
 pub(crate) trait GemmKernel {
@@ -27,9 +29,13 @@ pub(crate) trait GemmKernel {
     /// Whether to always use the masked wrapper around the kernel.
     fn always_masked() -> bool;
 
-    fn nc() -> usize;
-    fn kc() -> usize;
-    fn mc() -> usize;
+    // These should ideally be tuned per kernel and per microarch
+    #[inline(always)]
+    fn nc() -> usize { archparam::S_NC }
+    #[inline(always)]
+    fn kc() -> usize { archparam::S_KC }
+    #[inline(always)]
+    fn mc() -> usize { archparam::S_MC }
 
     /// Matrix multiplication kernel
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 - 2018 Ulrik Sverdrup "bluss"
+// Copyright 2016 - 2021 Ulrik Sverdrup "bluss"
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -129,3 +129,15 @@ mod sgemm_kernel;
 
 pub use crate::gemm::dgemm;
 pub use crate::gemm::sgemm;
+
+#[cfg(feature = "cgemm")]
+mod cgemm_kernel;
+#[cfg(feature = "cgemm")]
+mod zgemm_kernel;
+
+#[cfg(feature = "cgemm")]
+pub use crate::gemm::cgemm;
+#[cfg(feature = "cgemm")]
+pub use crate::gemm::zgemm;
+#[cfg(feature = "cgemm")]
+pub use crate::gemm::CGemmOption;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,9 @@ pub use crate::gemm::dgemm;
 pub use crate::gemm::sgemm;
 
 #[cfg(feature = "cgemm")]
+#[macro_use]
+mod cgemm_common;
+#[cfg(feature = "cgemm")]
 mod cgemm_kernel;
 #[cfg(feature = "cgemm")]
 mod zgemm_kernel;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,15 @@
 //! `MATMUL_NUM_THREADS` decides how many threads are used at maximum. At the moment 1-4 are
 //! supported and the default is the number of physical cpus (as detected by `num_cpus`).
 //!
+//! ### `cgemm`
+//!
+//! `cgemm` is an optional crate feature.
+//!
+//! It enables the `cgemm` and `zgemm` methods for complex matrix multiplication.
+//! This is an **experimental feature** and not yet as performant as the float kernels on x86.
+//!
+//! The complex representation we use is `[f64; 2]`.
+//!
 //! ## Other Notes
 //!
 //! The functions in this crate are thread safe, as long as the destination

--- a/src/loopmacros.rs
+++ b/src/loopmacros.rs
@@ -27,6 +27,14 @@ macro_rules! loop4 {
     }
 }
 
+#[cfg(feature = "cgemm")]
+macro_rules! loop2 {
+    ($i:ident, $e:expr) => {{
+        let $i = 0; $e;
+        let $i = 1; $e;
+    }}
+}
+
 #[cfg(not(debug_assertions))]
 macro_rules! loop4 {
     ($i:ident, $e:expr) => {{

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -555,7 +555,7 @@ mod tests {
     mod test_arch_kernels {
         use super::test_a_kernel;
         use super::super::*;
-        #[cfg(features = "std")]
+        #[cfg(feature = "std")]
         use std::println;
         macro_rules! test_arch_kernels_x86 {
             ($($feature_name:tt, $name:ident, $kernel_ty:ty),*) => {
@@ -565,7 +565,7 @@ mod tests {
                     if is_x86_feature_detected_!($feature_name) {
                         test_a_kernel::<$kernel_ty>(stringify!($name));
                     } else {
-                        #[cfg(features = "std")]
+                        #[cfg(feature = "std")]
                         println!("Skipping, host does not have feature: {:?}", $feature_name);
                     }
                 }

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -499,44 +499,11 @@ unsafe fn at(ptr: *const T, i: usize) -> T {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::vec;
-    use crate::aligned_alloc::Alloc;
-
-    fn aligned_alloc<K>(elt: K::Elem, n: usize) -> Alloc<K::Elem>
-        where K: GemmKernel,
-              K::Elem: Copy,
-    {
-        unsafe {
-            Alloc::new(n, K::align_to()).init_with(elt)
-        }
-    }
-
-    use super::T;
-
-    fn test_a_kernel<K: GemmKernel<Elem=T>>(_name: &str) {
-        const K: usize = 4;
-        let mr = K::MR;
-        let nr = K::NR;
-        let mut a = aligned_alloc::<K>(1., mr * K);
-        let mut b = aligned_alloc::<K>(0., nr * K);
-        for (i, x) in a.iter_mut().enumerate() {
-            *x = i as _;
-        }
-
-        for i in 0..K {
-            b[i + i * nr] = 1.;
-        }
-        let mut c = vec![0.; mr * nr];
-        unsafe {
-            K::kernel(K, 1., &a[0], &b[0], 0., &mut c[0], 1, mr as isize);
-            // col major C
-        }
-        assert_eq!(&a[..], &c[..a.len()]);
-    }
+    use crate::kernel::test::test_a_kernel;
 
     #[test]
     fn test_kernel_fallback_impl() {
-        test_a_kernel::<KernelFallback>("kernel");
+        test_a_kernel::<KernelFallback, _>("kernel");
     }
 
     #[cfg(any(target_arch="x86", target_arch="x86_64"))]
@@ -563,7 +530,7 @@ mod tests {
                 #[test]
                 fn $name() {
                     if is_x86_feature_detected_!($feature_name) {
-                        test_a_kernel::<$kernel_ty>(stringify!($name));
+                        test_a_kernel::<$kernel_ty, _>(stringify!($name));
                     } else {
                         #[cfg(feature = "std")]
                         println!("Skipping, host does not have feature: {:?}", $feature_name);

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -124,7 +124,7 @@ impl LoopThreadConfig {
     fn new_impl(m: usize, k: usize, n: usize, max_threads: usize, kmc: usize) -> Self {
         // use a heuristic to try not to use too many threads for smaller matrices
         let size_factor = m * k + k * n;
-        let thread_factor = 1 << 16;
+        let thread_factor = 1 << 14;
         // pure guesswork in terms of what the default should be
         let arch_factor = if cfg!(any(target_arch="arm", target_arch="aarch64")) {
             20

--- a/src/zgemm_kernel.rs
+++ b/src/zgemm_kernel.rs
@@ -1,0 +1,236 @@
+// Copyright 2016 - 2021 Ulrik Sverdrup "bluss"
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::kernel::GemmKernel;
+use crate::kernel::GemmSelect;
+use crate::kernel::{U2, U4, c64, Element, c64_mul as mul};
+
+
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+struct KernelSse2;
+struct KernelFallback;
+
+type T = c64;
+
+/// Detect which implementation to use and select it using the selector's
+/// .select(Kernel) method.
+///
+/// This function is called one or more times during a whole program's
+/// execution, it may be called for each gemm kernel invocation or fewer times.
+#[inline]
+pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
+    // dispatch to specific compiled versions
+    #[cfg(any(target_arch="x86", target_arch="x86_64"))]
+    {
+        if is_x86_feature_detected_!("sse2") {
+            return selector.select(KernelSse2);
+        }
+    }
+    return selector.select(KernelFallback);
+}
+
+#[cfg(all(test, any(target_arch="x86", target_arch="x86_64")))]
+macro_rules! loop_m { ($i:ident, $e:expr) => { loop4!($i, $e) }; }
+#[cfg(test)]
+macro_rules! loop_n { ($j:ident, $e:expr) => { loop2!($j, $e) }; }
+
+
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+impl GemmKernel for KernelSse2 {
+    type Elem = T;
+
+    type MRTy = <KernelFallback as GemmKernel>::MRTy;
+    type NRTy = <KernelFallback as GemmKernel>::NRTy;
+
+    #[inline(always)]
+    fn align_to() -> usize { 16 }
+
+    #[inline(always)]
+    fn always_masked() -> bool { KernelFallback::always_masked() }
+
+    #[inline(always)]
+    unsafe fn kernel(
+        k: usize,
+        alpha: T,
+        a: *const T,
+        b: *const T,
+        beta: T,
+        c: *mut T, rsc: isize, csc: isize) {
+        kernel_target_sse2(k, alpha, a, b, beta, c, rsc, csc)
+    }
+}
+
+impl GemmKernel for KernelFallback {
+    type Elem = T;
+
+    type MRTy = U4;
+    type NRTy = U2;
+
+    #[inline(always)]
+    fn align_to() -> usize { 0 }
+
+    #[inline(always)]
+    fn always_masked() -> bool { true }
+
+    #[inline(always)]
+    unsafe fn kernel(
+        k: usize,
+        alpha: T,
+        a: *const T,
+        b: *const T,
+        beta: T,
+        c: *mut T, rsc: isize, csc: isize) {
+        kernel_fallback_impl(k, alpha, a, b, beta, c, rsc, csc)
+    }
+}
+
+#[inline]
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+#[target_feature(enable="sse2")]
+unsafe fn kernel_target_sse2(k: usize, alpha: T, a: *const T, b: *const T,
+                             beta: T, c: *mut T, rsc: isize, csc: isize)
+{
+    kernel_fallback_impl(k, alpha, a, b, beta, c, rsc, csc)
+}
+
+#[inline]
+unsafe fn kernel_fallback_impl(k: usize, alpha: T, a: *const T, b: *const T,
+                               beta: T, c: *mut T, rsc: isize, csc: isize)
+{
+    const MR: usize = KernelFallback::MR;
+    const NR: usize = KernelFallback::NR;
+    let mut ab: [[T; NR]; MR] = [[T::zero(); NR]; MR];
+    let mut a = a;
+    let mut b = b;
+    debug_assert_eq!(beta, T::zero(), "Beta must be 0 or is not masked");
+
+    // Compute A B into ab[i][j]
+    unroll_by!(4 => k, {
+        loop4!(i, loop2!(j, ab[i][j].add_assign(mul(at(a, i), at(b, j)))));
+
+        a = a.offset(MR as isize);
+        b = b.offset(NR as isize);
+    });
+
+    macro_rules! c {
+        ($i:expr, $j:expr) => (c.offset(rsc * $i as isize + csc * $j as isize));
+    }
+
+    // set C = α A B
+    loop2!(j, loop4!(i, *c![i, j] = mul(alpha, ab[i][j])));
+}
+
+#[inline(always)]
+unsafe fn at(ptr: *const T, i: usize) -> T {
+    *ptr.offset(i as isize)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::vec;
+    use crate::aligned_alloc::Alloc;
+
+    fn aligned_alloc<K>(elt: K::Elem, n: usize) -> Alloc<K::Elem>
+        where K: GemmKernel,
+              K::Elem: Copy,
+    {
+        unsafe {
+            Alloc::new(n, K::align_to()).init_with(elt)
+        }
+    }
+
+    use super::T;
+
+    fn test_a_kernel<K: GemmKernel<Elem=T>>(_name: &str) {
+        const K: usize = 4;
+        let mr = K::MR;
+        let nr = K::NR;
+        let mut a = aligned_alloc::<K>(T::one(), mr * K);
+        let mut b = aligned_alloc::<K>(T::zero(), nr * K);
+        for (i, x) in a.iter_mut().enumerate() {
+            *x = [i as _, 1.];
+        }
+
+        for i in 0..Ord::min(K, nr) {
+            b[i + i * nr] = T::one(); 
+        }
+
+        let mut c = vec![T::zero(); mr * nr];
+        unsafe {
+            K::kernel(K, T::one(), &a[0], &b[0], T::zero(), &mut c[0], 1, mr as isize);
+            // col major C
+        }
+        let common_len = Ord::min(a.len(), c.len());
+        assert_eq!(&a[..common_len], &c[..common_len]);
+    }
+
+    #[test]
+    fn test_kernel_fallback_impl() {
+        test_a_kernel::<KernelFallback>("kernel");
+    }
+
+    #[cfg(any(target_arch="x86", target_arch="x86_64"))]
+    #[test]
+    fn test_loop_m_n() {
+        let mut m = [[0; KernelSse2::NR]; KernelSse2::MR];
+        loop_m!(i, loop_n!(j, m[i][j] += 1));
+        for arr in &m[..] {
+            for elt in &arr[..] {
+                assert_eq!(*elt, 1);
+            }
+        }
+    }
+
+    #[cfg(any(target_arch="x86", target_arch="x86_64"))]
+    mod test_arch_kernels {
+        use super::test_a_kernel;
+        use super::super::*;
+        #[cfg(feature = "std")]
+        use std::println;
+        macro_rules! test_arch_kernels_x86 {
+            ($($feature_name:tt, $name:ident, $kernel_ty:ty),*) => {
+                $(
+                #[test]
+                fn $name() {
+                    if is_x86_feature_detected_!($feature_name) {
+                        test_a_kernel::<$kernel_ty>(stringify!($name));
+                    } else {
+                        #[cfg(feature = "std")]
+                        println!("Skipping, host does not have feature: {:?}", $feature_name);
+                    }
+                }
+                )*
+            }
+        }
+
+        test_arch_kernels_x86! {
+            "sse2", sse2, KernelSse2
+        }
+
+        #[test]
+        fn ensure_target_features_tested() {
+            // If enabled, this test ensures that the requested feature actually
+            // was enabled on this configuration, so that it was tested.
+            let should_ensure_feature = !option_env!("MMTEST_ENSUREFEATURE")
+                                                    .unwrap_or("").is_empty();
+            if !should_ensure_feature {
+                // skip
+                return;
+            }
+            let feature_name = option_env!("MMTEST_FEATURE")
+                                          .expect("No MMTEST_FEATURE configured!");
+            let detected = match feature_name {
+                "sse2" => is_x86_feature_detected_!("sse2"),
+                _ => false,
+            };
+            assert!(detected, "Feature {:?} was not detected, so it could not be tested",
+                    feature_name);
+        }
+    }
+}

--- a/src/zgemm_kernel.rs
+++ b/src/zgemm_kernel.rs
@@ -9,6 +9,7 @@
 use crate::kernel::GemmKernel;
 use crate::kernel::GemmSelect;
 use crate::kernel::{U2, U4, c64, Element, c64_mul as mul};
+use crate::archparam;
 
 
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
@@ -56,6 +57,13 @@ impl GemmKernel for KernelFma {
     fn always_masked() -> bool { KernelFallback::always_masked() }
 
     #[inline(always)]
+    fn nc() -> usize { archparam::Z_NC }
+    #[inline(always)]
+    fn kc() -> usize { archparam::Z_KC }
+    #[inline(always)]
+    fn mc() -> usize { archparam::Z_MC }
+
+    #[inline(always)]
     unsafe fn kernel(
         k: usize,
         alpha: T,
@@ -81,6 +89,13 @@ impl GemmKernel for KernelSse2 {
     fn always_masked() -> bool { KernelFallback::always_masked() }
 
     #[inline(always)]
+    fn nc() -> usize { archparam::Z_NC }
+    #[inline(always)]
+    fn kc() -> usize { archparam::Z_KC }
+    #[inline(always)]
+    fn mc() -> usize { archparam::Z_MC }
+
+    #[inline(always)]
     unsafe fn kernel(
         k: usize,
         alpha: T,
@@ -103,6 +118,13 @@ impl GemmKernel for KernelFallback {
 
     #[inline(always)]
     fn always_masked() -> bool { true }
+
+    #[inline(always)]
+    fn nc() -> usize { archparam::Z_NC }
+    #[inline(always)]
+    fn kc() -> usize { archparam::Z_KC }
+    #[inline(always)]
+    fn mc() -> usize { archparam::Z_MC }
 
     #[inline(always)]
     unsafe fn kernel(

--- a/src/zgemm_kernel.rs
+++ b/src/zgemm_kernel.rs
@@ -164,46 +164,11 @@ unsafe fn at(ptr: *const T, i: usize) -> T {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::vec;
-    use crate::aligned_alloc::Alloc;
-
-    fn aligned_alloc<K>(elt: K::Elem, n: usize) -> Alloc<K::Elem>
-        where K: GemmKernel,
-              K::Elem: Copy,
-    {
-        unsafe {
-            Alloc::new(n, K::align_to()).init_with(elt)
-        }
-    }
-
-    use super::T;
-
-    fn test_a_kernel<K: GemmKernel<Elem=T>>(_name: &str) {
-        const K: usize = 4;
-        let mr = K::MR;
-        let nr = K::NR;
-        let mut a = aligned_alloc::<K>(T::one(), mr * K);
-        let mut b = aligned_alloc::<K>(T::zero(), nr * K);
-        for (i, x) in a.iter_mut().enumerate() {
-            *x = [i as _, 1.];
-        }
-
-        for i in 0..Ord::min(K, nr) {
-            b[i + i * nr] = T::one(); 
-        }
-
-        let mut c = vec![T::zero(); mr * nr];
-        unsafe {
-            K::kernel(K, T::one(), &a[0], &b[0], T::zero(), &mut c[0], 1, mr as isize);
-            // col major C
-        }
-        let common_len = Ord::min(a.len(), c.len());
-        assert_eq!(&a[..common_len], &c[..common_len]);
-    }
+    use crate::kernel::test::test_a_kernel;
 
     #[test]
     fn test_kernel_fallback_impl() {
-        test_a_kernel::<KernelFallback>("kernel");
+        test_a_kernel::<KernelFallback, _>("kernel");
     }
 
     #[cfg(any(target_arch="x86", target_arch="x86_64"))]
@@ -230,7 +195,7 @@ mod tests {
                 #[test]
                 fn $name() {
                     if is_x86_feature_detected_!($feature_name) {
-                        test_a_kernel::<$kernel_ty>(stringify!($name));
+                        test_a_kernel::<$kernel_ty, _>(stringify!($name));
                     } else {
                         #[cfg(feature = "std")]
                         println!("Skipping, host does not have feature: {:?}", $feature_name);
@@ -243,26 +208,6 @@ mod tests {
         test_arch_kernels_x86! {
             "fma", fma, KernelFma,
             "sse2", sse2, KernelSse2
-        }
-
-        #[test]
-        fn ensure_target_features_tested() {
-            // If enabled, this test ensures that the requested feature actually
-            // was enabled on this configuration, so that it was tested.
-            let should_ensure_feature = !option_env!("MMTEST_ENSUREFEATURE")
-                                                    .unwrap_or("").is_empty();
-            if !should_ensure_feature {
-                // skip
-                return;
-            }
-            let feature_name = option_env!("MMTEST_FEATURE")
-                                          .expect("No MMTEST_FEATURE configured!");
-            let detected = match feature_name {
-                "sse2" => is_x86_feature_detected_!("sse2"),
-                _ => false,
-            };
-            assert!(detected, "Feature {:?} was not detected, so it could not be tested",
-                    feature_name);
         }
     }
 }

--- a/testdefs/testdefs.rs
+++ b/testdefs/testdefs.rs
@@ -8,9 +8,15 @@ use matrixmultiply::{cgemm, zgemm, CGemmOption};
 pub trait Float : Copy + std::fmt::Debug + PartialEq {
     fn zero() -> Self;
     fn one() -> Self;
+    // construct as number x
     fn from(x: i64) -> Self;
+    // construct as number x + yi, but ignore y if not complex
+    fn from2(x: i64, _y: i64) -> Self { Self::from(x) }
     fn nan() -> Self;
+    fn real(self) -> Self { self }
+    fn imag(self) -> Self { self }
     fn is_nan(self) -> bool;
+    fn is_complex() -> bool { false }
 }
 
 impl Float for f32 {
@@ -41,8 +47,12 @@ impl Float for c32 {
     fn zero() -> Self { [0., 0.] }
     fn one() -> Self { [1., 0.] }
     fn from(x: i64) -> Self { [x as _, 0.] }
+    fn from2(x: i64, y: i64) -> Self { [x as _, y as _] }
     fn nan() -> Self { [0./0., 0./0.] }
+    fn real(self) -> Self { [self[0], 0.] }
+    fn imag(self) -> Self { [self[1], 0.] }
     fn is_nan(self) -> bool { self[0].is_nan() || self[1].is_nan() }
+    fn is_complex() -> bool { true }
 }
 
 #[cfg(feature="cgemm")]
@@ -50,8 +60,12 @@ impl Float for c64 {
     fn zero() -> Self { [0., 0.] }
     fn one() -> Self { [1., 0.] }
     fn from(x: i64) -> Self { [x as _, 0.] }
+    fn from2(x: i64, y: i64) -> Self { [x as _, y as _] }
     fn nan() -> Self { [0./0., 0./0.] }
+    fn real(self) -> Self { [self[0], 0.] }
+    fn imag(self) -> Self { [self[1], 0.] }
     fn is_nan(self) -> bool { self[0].is_nan() || self[1].is_nan() }
+    fn is_complex() -> bool { true }
 }
 
 

--- a/testdefs/testdefs.rs
+++ b/testdefs/testdefs.rs
@@ -1,0 +1,146 @@
+
+use matrixmultiply::{sgemm, dgemm};
+#[cfg(feature="cgemm")]
+use matrixmultiply::{cgemm, zgemm, CGemmOption};
+
+// Common code for tests - generic treatment of f32, f64, c32, c64 and Gemm
+
+pub trait Float : Copy + std::fmt::Debug + PartialEq {
+    fn zero() -> Self;
+    fn one() -> Self;
+    fn from(x: i64) -> Self;
+    fn nan() -> Self;
+    fn is_nan(self) -> bool;
+}
+
+impl Float for f32 {
+    fn zero() -> Self { 0. }
+    fn one() -> Self { 1. }
+    fn from(x: i64) -> Self { x as Self }
+    fn nan() -> Self { 0./0. }
+    fn is_nan(self) -> bool { self.is_nan() }
+}
+
+impl Float for f64 {
+    fn zero() -> Self { 0. }
+    fn one() -> Self { 1. }
+    fn from(x: i64) -> Self { x as Self }
+    fn nan() -> Self { 0./0. }
+    fn is_nan(self) -> bool { self.is_nan() }
+}
+
+#[allow(non_camel_case_types)]
+#[cfg(feature="cgemm")]
+pub type c32 = [f32; 2];
+#[allow(non_camel_case_types)]
+#[cfg(feature="cgemm")]
+pub type c64 = [f64; 2];
+
+#[cfg(feature="cgemm")]
+impl Float for c32 {
+    fn zero() -> Self { [0., 0.] }
+    fn one() -> Self { [1., 0.] }
+    fn from(x: i64) -> Self { [x as _, 0.] }
+    fn nan() -> Self { [0./0., 0./0.] }
+    fn is_nan(self) -> bool { self[0].is_nan() || self[1].is_nan() }
+}
+
+#[cfg(feature="cgemm")]
+impl Float for c64 {
+    fn zero() -> Self { [0., 0.] }
+    fn one() -> Self { [1., 0.] }
+    fn from(x: i64) -> Self { [x as _, 0.] }
+    fn nan() -> Self { [0./0., 0./0.] }
+    fn is_nan(self) -> bool { self[0].is_nan() || self[1].is_nan() }
+}
+
+
+
+pub trait Gemm : Sized {
+    unsafe fn gemm(
+        m: usize, k: usize, n: usize,
+        alpha: Self,
+        a: *const Self, rsa: isize, csa: isize,
+        b: *const Self, rsb: isize, csb: isize,
+        beta: Self,
+        c: *mut Self, rsc: isize, csc: isize);
+}
+
+impl Gemm for f32 {
+    unsafe fn gemm(
+        m: usize, k: usize, n: usize,
+        alpha: Self,
+        a: *const Self, rsa: isize, csa: isize,
+        b: *const Self, rsb: isize, csb: isize,
+        beta: Self,
+        c: *mut Self, rsc: isize, csc: isize) {
+        sgemm(
+            m, k, n,
+            alpha,
+            a, rsa, csa,
+            b, rsb, csb,
+            beta,
+            c, rsc, csc)
+    }
+}
+
+impl Gemm for f64 {
+    unsafe fn gemm(
+        m: usize, k: usize, n: usize,
+        alpha: Self,
+        a: *const Self, rsa: isize, csa: isize,
+        b: *const Self, rsb: isize, csb: isize,
+        beta: Self,
+        c: *mut Self, rsc: isize, csc: isize) {
+        dgemm(
+            m, k, n,
+            alpha,
+            a, rsa, csa,
+            b, rsb, csb,
+            beta,
+            c, rsc, csc)
+    }
+}
+
+#[cfg(feature="cgemm")]
+impl Gemm for c32 {
+    unsafe fn gemm(
+        m: usize, k: usize, n: usize,
+        alpha: Self,
+        a: *const Self, rsa: isize, csa: isize,
+        b: *const Self, rsb: isize, csb: isize,
+        beta: Self,
+        c: *mut Self, rsc: isize, csc: isize) {
+        cgemm(
+            CGemmOption::Standard,
+            CGemmOption::Standard,
+            m, k, n,
+            alpha,
+            a, rsa, csa,
+            b, rsb, csb,
+            beta,
+            c, rsc, csc)
+    }
+}
+
+#[cfg(feature="cgemm")]
+impl Gemm for c64 {
+    unsafe fn gemm(
+        m: usize, k: usize, n: usize,
+        alpha: Self,
+        a: *const Self, rsa: isize, csa: isize,
+        b: *const Self, rsb: isize, csb: isize,
+        beta: Self,
+        c: *mut Self, rsc: isize, csc: isize) {
+        zgemm(
+            CGemmOption::Standard,
+            CGemmOption::Standard,
+            m, k, n,
+            alpha,
+            a, rsa, csa,
+            b, rsb, csb,
+            beta,
+            c, rsc, csc)
+    }
+}
+

--- a/tests/sgemm.rs
+++ b/tests/sgemm.rs
@@ -231,39 +231,72 @@ fn test_scale<F>(m: usize, k: usize, n: usize, small: bool)
     // init c2 with NaN to test the overwriting behavior when beta = 0.
 
     for (i, elt) in a.iter_mut().enumerate() {
-        *elt = F::from(i as i64);
+        *elt = F::from2(i as i64, i as i64);
     }
     for (i, elt) in b.iter_mut().enumerate() {
-        *elt = F::from(i as i64);
+        *elt = F::from2(i as i64, i as i64);
+    }
+
+    let alpha1;
+    let beta1 = F::zero();
+    let alpha21;
+    let beta21;
+    let alpha22;
+    let beta22;
+
+    if !F::is_complex() {
+        // 3 A B == C in this way:
+        // C <- A B
+        // C <- A B + 2 C
+        alpha1 = F::from(3);
+
+        alpha21 = F::one();
+        beta21 = F::zero();
+        alpha22 = F::one();
+        beta22 = F::from(2);
+    } else {
+        // Select constants in a way that makes the complex values
+        // significant for the complex case. Using i² = -1 to make sure.
+        //
+        // (2 + 3i) A B == C in this way:
+        // C <- (1 + i) A B
+        // C <- A B + (2 + i) C  == (3 + 3i - 1) A B
+        alpha1 = F::from2(2, 3);
+
+        alpha21 = F::from2(1, 1);
+        beta21 = F::zero();
+        alpha22 = F::one();
+        beta22 = F::from2(2, 1);
     }
 
     unsafe {
-        // C1 = 3 A B
+        // C1 = alpha1 A B
         F::gemm(
             m, k, n,
-            F::from(3),
+            alpha1,
             a.as_ptr(), k as isize, 1,
             b.as_ptr(), n as isize, 1,
-            F::zero(),
+            beta1,
             c1.as_mut_ptr(), n as isize, 1,
         );
 
-        // C2 = A B 
+        // C2 = alpha21 A B
         F::gemm(
             m, k, n,
-            F::one(),
+            alpha21,
             a.as_ptr(), k as isize, 1,
             b.as_ptr(), n as isize, 1,
-            F::zero(),
+            beta21,
             c2.as_mut_ptr(), n as isize, 1,
         );
-        // C2 = A B + 2 C2
+
+        // C2 = A B + beta22 C2
         F::gemm(
             m, k, n,
-            F::one(),
+            alpha22,
             a.as_ptr(), k as isize, 1,
             b.as_ptr(), n as isize, 1,
-            F::from(2),
+            beta22,
             c2.as_mut_ptr(), n as isize, 1,
         );
     }

--- a/tests/sgemm.rs
+++ b/tests/sgemm.rs
@@ -1,12 +1,8 @@
-#![allow(non_camel_case_types)]
-
 extern crate core;
 extern crate itertools;
 extern crate matrixmultiply;
 
-use matrixmultiply::{sgemm, dgemm};
-#[cfg(feature="cgemm")]
-use matrixmultiply::{cgemm, zgemm, CGemmOption};
+include!("../testdefs/testdefs.rs");
 
 use itertools::Itertools;
 use itertools::{
@@ -17,143 +13,6 @@ use itertools::{
 use core::fmt::Debug;
 
 const FAST_TEST: Option<&'static str> = option_env!("MMTEST_FAST_TEST");
-
-trait Float : Copy + Debug + PartialEq {
-    fn zero() -> Self;
-    fn one() -> Self;
-    fn from(x: i64) -> Self;
-    fn nan() -> Self;
-    fn is_nan(self) -> bool;
-}
-
-impl Float for f32 {
-    fn zero() -> Self { 0. }
-    fn one() -> Self { 1. }
-    fn from(x: i64) -> Self { x as Self }
-    fn nan() -> Self { 0./0. }
-    fn is_nan(self) -> bool { self.is_nan() }
-}
-
-impl Float for f64 {
-    fn zero() -> Self { 0. }
-    fn one() -> Self { 1. }
-    fn from(x: i64) -> Self { x as Self }
-    fn nan() -> Self { 0./0. }
-    fn is_nan(self) -> bool { self.is_nan() }
-}
-
-#[cfg(feature="cgemm")]
-type c32 = [f32; 2];
-#[cfg(feature="cgemm")]
-type c64 = [f64; 2];
-
-#[cfg(feature="cgemm")]
-impl Float for c32 {
-    fn zero() -> Self { [0., 0.] }
-    fn one() -> Self { [1., 0.] }
-    fn from(x: i64) -> Self { [x as _, 0.] }
-    fn nan() -> Self { [0./0., 0./0.] }
-    fn is_nan(self) -> bool { self[0].is_nan() || self[1].is_nan() }
-}
-
-#[cfg(feature="cgemm")]
-impl Float for c64 {
-    fn zero() -> Self { [0., 0.] }
-    fn one() -> Self { [1., 0.] }
-    fn from(x: i64) -> Self { [x as _, 0.] }
-    fn nan() -> Self { [0./0., 0./0.] }
-    fn is_nan(self) -> bool { self[0].is_nan() || self[1].is_nan() }
-}
-
-
-
-trait Gemm : Sized {
-    unsafe fn gemm(
-        m: usize, k: usize, n: usize,
-        alpha: Self,
-        a: *const Self, rsa: isize, csa: isize,
-        b: *const Self, rsb: isize, csb: isize,
-        beta: Self,
-        c: *mut Self, rsc: isize, csc: isize);
-}
-
-impl Gemm for f32 {
-    unsafe fn gemm(
-        m: usize, k: usize, n: usize,
-        alpha: Self,
-        a: *const Self, rsa: isize, csa: isize,
-        b: *const Self, rsb: isize, csb: isize,
-        beta: Self,
-        c: *mut Self, rsc: isize, csc: isize) {
-        sgemm(
-            m, k, n,
-            alpha,
-            a, rsa, csa,
-            b, rsb, csb,
-            beta,
-            c, rsc, csc)
-    }
-}
-
-impl Gemm for f64 {
-    unsafe fn gemm(
-        m: usize, k: usize, n: usize,
-        alpha: Self,
-        a: *const Self, rsa: isize, csa: isize,
-        b: *const Self, rsb: isize, csb: isize,
-        beta: Self,
-        c: *mut Self, rsc: isize, csc: isize) {
-        dgemm(
-            m, k, n,
-            alpha,
-            a, rsa, csa,
-            b, rsb, csb,
-            beta,
-            c, rsc, csc)
-    }
-}
-
-#[cfg(feature="cgemm")]
-impl Gemm for c32 {
-    unsafe fn gemm(
-        m: usize, k: usize, n: usize,
-        alpha: Self,
-        a: *const Self, rsa: isize, csa: isize,
-        b: *const Self, rsb: isize, csb: isize,
-        beta: Self,
-        c: *mut Self, rsc: isize, csc: isize) {
-        cgemm(
-            CGemmOption::Standard,
-            CGemmOption::Standard,
-            m, k, n,
-            alpha,
-            a, rsa, csa,
-            b, rsb, csb,
-            beta,
-            c, rsc, csc)
-    }
-}
-
-#[cfg(feature="cgemm")]
-impl Gemm for c64 {
-    unsafe fn gemm(
-        m: usize, k: usize, n: usize,
-        alpha: Self,
-        a: *const Self, rsa: isize, csa: isize,
-        b: *const Self, rsb: isize, csb: isize,
-        beta: Self,
-        c: *mut Self, rsc: isize, csc: isize) {
-        zgemm(
-            CGemmOption::Standard,
-            CGemmOption::Standard,
-            m, k, n,
-            alpha,
-            a, rsa, csa,
-            b, rsb, csb,
-            beta,
-            c, rsc, csc)
-    }
-}
 
 #[test]
 fn test_sgemm() {


### PR DESCRIPTION
Use the feature name "cgemm" for cgemm/zgemm methods; start them
off by adding fallback implementations using 4x2 kernels.

CGemmOptions added as a placeholder - can later include options for
conjugating either operand (transpose not required - the strides provide
that freedom already).

Extensive updates for benchmarks, a simple argument parser
makes it easier to use.

Better testing, refactoring some common code and better test coverage.

Complex is using the representation [f64; 2] here which is
representation compatible in memory with C and with num_complex.