### PR TITLE
Allow tweaking size parameters at compile time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ cgemm = []
 threading = ["thread-tree", "std", "once_cell", "num_cpus"]
 std = []
 
+# support for compile-time configuration
+constconf = []
+
+
 [profile.release]
 debug = true
 [profile.bench]

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,5 @@
-Copyright (c) 2016 - 2018 Ulrik Sverdrup "bluss"
+Copyright (c) 2016 - 2021 Ulrik Sverdrup "bluss"
+Copyright (c) 2021 DutchGhost [constparse.rs]
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/src/archparam.rs
+++ b/src/archparam.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 - 2018 Ulrik Sverdrup "bluss"
+// Copyright 2016 - 2021 Ulrik Sverdrup "bluss"
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -6,109 +6,41 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 //! architechture specific parameters
+//!
+//! NC: Columns in C, B that we handle at a time. (5th loop)
+//! KC: Rows of Bj at a time (4th loop)
+//! MC: Rows of Ap at a time. (3rd loop)
 
-/// Columns in C, B that we handle at a time. (5th loop)
-///
-/// Cuts B into B0, B1, .. Bj, .. B_NC
-pub const S_NC: usize = 1024;
+use crate::archparam_defaults;
+use crate::constparse::parse_unwarp;
 
-/// Rows of Bj at a time (4th loop)
-///
-/// Columns of A at a time.
-///
-/// Cuts A into Ap
-///
-/// Cuts Bj into Bp, which is packed into B~.
-///
-/// Size of B~ is NC x KC
-pub const S_KC: usize = 256;
+macro_rules! conf_env_or_default {
+    ($env_name:tt, $default:expr) => {
+        match option_env!($env_name) {
+            Some(x) => parse_unwarp(x),
+            None => $default,
+        }
+    }
+}
 
-/// Rows of Ap at a time. (3rd loop)
-///
-/// Cuts Ap into A0, A1, .., Ai, .. A_MC
-///
-/// Ai is packed into A~.
-///
-/// Size of A~ is KC x MC
-pub const S_MC: usize = 64;
+pub(crate) const S_NC: usize = conf_env_or_default!("MATMUL_SGEMM_NC", archparam_defaults::S_NC);
+pub(crate) const S_KC: usize = conf_env_or_default!("MATMUL_SGEMM_KC", archparam_defaults::S_KC);
+pub(crate) const S_MC: usize = conf_env_or_default!("MATMUL_SGEMM_MC", archparam_defaults::S_MC);
 
-/// Columns in C, B that we handle at a time. (5th loop)
-///
-/// Cuts B into B0, B1, .. Bj, .. B_NC
-pub const D_NC: usize = 1024;
-
-/// Rows of Bj at a time (4th loop)
-///
-/// Columns of A at a time.
-///
-/// Cuts A into Ap
-///
-/// Cuts Bj into Bp, which is packed into B~.
-///
-/// Size of B~ is NC x KC
-pub const D_KC: usize = 256;
-
-/// Rows of Ap at a time. (3rd loop)
-///
-/// Cuts Ap into A0, A1, .., Ai, .. A_MC
-///
-/// Ai is packed into A~.
-///
-/// Size of A~ is KC x MC
-pub const D_MC: usize = 64;
+pub(crate) const D_NC: usize = conf_env_or_default!("MATMUL_DGEMM_NC", archparam_defaults::D_NC);
+pub(crate) const D_KC: usize = conf_env_or_default!("MATMUL_DGEMM_KC", archparam_defaults::D_KC);
+pub(crate) const D_MC: usize = conf_env_or_default!("MATMUL_DGEMM_MC", archparam_defaults::D_MC);
 
 #[cfg(feature = "cgemm")]
-/// Columns in C, B that we handle at a time. (5th loop)
-///
-/// Cuts B into B0, B1, .. Bj, .. B_NC
-pub const C_NC: usize = S_NC / 2;
+pub(crate) const C_NC: usize = conf_env_or_default!("MATMUL_CGEMM_NC", archparam_defaults::C_NC);
+#[cfg(feature = "cgemm")]
+pub(crate) const C_KC: usize = conf_env_or_default!("MATMUL_CGEMM_KC", archparam_defaults::C_KC);
+#[cfg(feature = "cgemm")]
+pub(crate) const C_MC: usize = conf_env_or_default!("MATMUL_CGEMM_MC", archparam_defaults::C_MC);
 
 #[cfg(feature = "cgemm")]
-/// Rows of Bj at a time (4th loop)
-///
-/// Columns of A at a time.
-///
-/// Cuts A into Ap
-///
-/// Cuts Bj into Bp, which is packed into B~.
-///
-/// Size of B~ is NC x KC
-pub const C_KC: usize = S_KC;
-
+pub(crate) const Z_NC: usize = conf_env_or_default!("MATMUL_ZGEMM_NC", archparam_defaults::Z_NC);
 #[cfg(feature = "cgemm")]
-/// Rows of Ap at a time. (3rd loop)
-///
-/// Cuts Ap into A0, A1, .., Ai, .. A_MC
-///
-/// Ai is packed into A~.
-///
-/// Size of A~ is KC x MC
-pub const C_MC: usize = S_MC / 2;
-
+pub(crate) const Z_KC: usize = conf_env_or_default!("MATMUL_ZGEMM_KC", archparam_defaults::Z_KC);
 #[cfg(feature = "cgemm")]
-/// Columns in C, B that we handle at a time. (5th loop)
-///
-/// Cuts B into B0, B1, .. Bj, .. B_NC
-pub const Z_NC: usize = D_NC / 2;
-
-#[cfg(feature = "cgemm")]
-/// Rows of Bj at a time (4th loop)
-///
-/// Columns of A at a time.
-///
-/// Cuts A into Ap
-///
-/// Cuts Bj into Bp, which is packed into B~.
-///
-/// Size of B~ is NC x KC
-pub const Z_KC: usize = D_KC;
-
-#[cfg(feature = "cgemm")]
-/// Rows of Ap at a time. (3rd loop)
-///
-/// Cuts Ap into A0, A1, .., Ai, .. A_MC
-///
-/// Ai is packed into A~.
-///
-/// Size of A~ is KC x MC
-pub const Z_MC: usize = D_MC / 2;
+pub(crate) const Z_MC: usize = conf_env_or_default!("MATMUL_ZGEMM_MC", archparam_defaults::Z_MC);

--- a/src/archparam_defaults.rs
+++ b/src/archparam_defaults.rs
@@ -1,0 +1,115 @@
+// Copyright 2016 - 2018 Ulrik Sverdrup "bluss"
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//! architechture specific parameters
+
+/// Columns in C, B that we handle at a time. (5th loop)
+///
+/// Cuts B into B0, B1, .. Bj, .. B_NC
+pub const S_NC: usize = 1024;
+//pub const S_NC: usize = option_env!("MATMUL_SGEMM_NC").map(parse_unwrap).unwrap_or(S_NC);
+
+/// Rows of Bj at a time (4th loop)
+///
+/// Columns of A at a time.
+///
+/// Cuts A into Ap
+///
+/// Cuts Bj into Bp, which is packed into B~.
+///
+/// Size of B~ is NC x KC
+pub const S_KC: usize = 256;
+
+/// Rows of Ap at a time. (3rd loop)
+///
+/// Cuts Ap into A0, A1, .., Ai, .. A_MC
+///
+/// Ai is packed into A~.
+///
+/// Size of A~ is KC x MC
+pub const S_MC: usize = 64;
+
+/// Columns in C, B that we handle at a time. (5th loop)
+///
+/// Cuts B into B0, B1, .. Bj, .. B_NC
+pub const D_NC: usize = 1024;
+
+/// Rows of Bj at a time (4th loop)
+///
+/// Columns of A at a time.
+///
+/// Cuts A into Ap
+///
+/// Cuts Bj into Bp, which is packed into B~.
+///
+/// Size of B~ is NC x KC
+pub const D_KC: usize = 256;
+
+/// Rows of Ap at a time. (3rd loop)
+///
+/// Cuts Ap into A0, A1, .., Ai, .. A_MC
+///
+/// Ai is packed into A~.
+///
+/// Size of A~ is KC x MC
+pub const D_MC: usize = 64;
+
+#[cfg(feature = "cgemm")]
+/// Columns in C, B that we handle at a time. (5th loop)
+///
+/// Cuts B into B0, B1, .. Bj, .. B_NC
+pub const C_NC: usize = S_NC / 2;
+
+#[cfg(feature = "cgemm")]
+/// Rows of Bj at a time (4th loop)
+///
+/// Columns of A at a time.
+///
+/// Cuts A into Ap
+///
+/// Cuts Bj into Bp, which is packed into B~.
+///
+/// Size of B~ is NC x KC
+pub const C_KC: usize = S_KC;
+
+#[cfg(feature = "cgemm")]
+/// Rows of Ap at a time. (3rd loop)
+///
+/// Cuts Ap into A0, A1, .., Ai, .. A_MC
+///
+/// Ai is packed into A~.
+///
+/// Size of A~ is KC x MC
+pub const C_MC: usize = S_MC / 2;
+
+#[cfg(feature = "cgemm")]
+/// Columns in C, B that we handle at a time. (5th loop)
+///
+/// Cuts B into B0, B1, .. Bj, .. B_NC
+pub const Z_NC: usize = D_NC / 2;
+
+#[cfg(feature = "cgemm")]
+/// Rows of Bj at a time (4th loop)
+///
+/// Columns of A at a time.
+///
+/// Cuts A into Ap
+///
+/// Cuts Bj into Bp, which is packed into B~.
+///
+/// Size of B~ is NC x KC
+pub const Z_KC: usize = D_KC;
+
+#[cfg(feature = "cgemm")]
+/// Rows of Ap at a time. (3rd loop)
+///
+/// Cuts Ap into A0, A1, .., Ai, .. A_MC
+///
+/// Ai is packed into A~.
+///
+/// Size of A~ is KC x MC
+pub const Z_MC: usize = D_MC / 2;

--- a/src/constparse.rs
+++ b/src/constparse.rs
@@ -1,0 +1,87 @@
+// Copyright (c) 2021 DutchGhost
+// Copyright (c) 2021 matrixmultiply authors
+//
+// Incorporpated in matrixmultiply under these terms, see main license files.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[derive(Clone, Copy)]
+pub(crate) enum ParseIntError {
+    InvalidDigit,
+}
+
+const fn parse_byte(b: u8, pow10: usize) -> Result<usize, ParseIntError> {
+    let r = b.wrapping_sub(48);
+
+    if r > 9 {
+        Err(ParseIntError::InvalidDigit)
+    } else {
+        Ok((r as usize) * pow10)
+    }
+}
+
+pub(crate) const POW10: [usize; 20] = {
+    let mut array = [0; 20];
+    let mut current = 1;
+
+    let mut index = 20;
+
+    loop {
+        index -= 1;
+        array[index] = current;
+
+        if index == 0 { break }
+
+        current *= 10;
+
+    }
+
+    array
+
+};
+
+/// Parse the input to integer; or otherwise cause
+/// a const error, an "unwarp" in space and time.
+pub(crate) const fn parse_unwarp(b: &str) -> usize {
+    match parse(b) {
+        Ok(t) => t,
+        res @ Err(_) => {
+            [0, /* const error: failed to parse environment variable */][res.is_err() as usize]
+        }
+    }
+}
+
+/// Parse the input to usize
+pub(crate) const fn parse(b: &str) -> Result<usize, ParseIntError> {
+    let bytes = b.as_bytes();
+
+    let mut result: usize = 0;
+
+    let len = bytes.len();
+
+    // Start at the correct index of the table,
+    // (skip the power's that are too large)
+    let mut index_const_table = POW10.len().wrapping_sub(len);
+    let mut index = 0;
+
+    while index < b.len() {
+        let a = bytes[index];
+        let p = POW10[index_const_table];
+
+        let r = match parse_byte(a, p) {
+            Err(e) => return Err(e),
+            Ok(d) => d,
+        };
+
+        result = result.wrapping_add(r);
+
+        index += 1;
+        index_const_table += 1;
+    }
+
+    Ok(result)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,14 @@
 //!
 //! The complex representation we use is `[f64; 2]`.
 //!
+//! ### `constconf`
+//!
+//! `constconf` is an optional feature. When enabled, cache-sensitive parameters of
+//! the gemm implementations can be tweaked *at compile time* by defining the following variables:
+//!
+//! - `MATMUL_SGEMM_MC`
+//!   (And so on, for S, D, C, ZGEMM and with NC, KC or MC).
+//!
 //! ## Other Notes
 //!
 //! The functions in this crate are thread safe, as long as the destination
@@ -121,7 +129,17 @@ extern crate core;
 mod debugmacros;
 #[macro_use]
 mod loopmacros;
+
+mod archparam_defaults;
+
+#[cfg(feature = "constconf")]
 mod archparam;
+#[cfg(feature = "constconf")]
+mod constparse;
+
+#[cfg(not(feature = "constconf"))]
+pub(crate) use archparam_defaults as archparam;
+
 mod gemm;
 mod kernel;
 mod ptr;

--- a/src/zgemm_kernel.rs
+++ b/src/zgemm_kernel.rs
@@ -11,7 +11,6 @@ use crate::kernel::GemmSelect;
 use crate::kernel::{U2, U4, c64, Element, c64_mul as mul};
 use crate::archparam;
 
-
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 struct KernelFma;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]


### PR DESCRIPTION
This introduces compile-time tweak environment variables like this:

- MATMUL_DGEMM_NC
- MATMUL_DGEMM_MC
- MATMUL_DGEMM_KC

etc for each gemm. These allow setting these size parameters at
compile time - they should ideally be optimized per kernel *and
microarch*.

Combine these parameters with the benchmark in ./examples/benchmark.rs
and its csv output option - this allows optimizing performance depending
on these parameters. This was already useful for complex.

Using DutchGhost's const parsing code from

https://gist.github.com/DutchGhost/d8604a3c796479777fe9f5e25d855cfd

which has been very useful.

Co-authored-by: DutchGhost <DutchGhost@users.noreply.github.com>