### PR TITLE
Run miri in the testuite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,3 +129,10 @@ jobs:
           MMTEST_FAST_TEST: 1
           RUSTFLAGS: -Copt-level=2
 
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Miri
+        run: ci/miri.sh --features cgemm
+

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -ex
+
+export CARGO_NET_RETRY=5
+export CARGO_NET_TIMEOUT=10
+
+MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
+echo "Installing latest nightly with Miri: $MIRI_NIGHTLY"
+rustup default "$MIRI_NIGHTLY"
+
+rustup component add miri
+cargo miri setup
+
+# disable isolation for num_cpus::get_physical
+MIRIFLAGS=-Zmiri-disable-isolation \
+MMTEST_FAST_TEST=1 \
+    cargo miri test "$@"

--- a/tests/sgemm.rs
+++ b/tests/sgemm.rs
@@ -59,14 +59,14 @@ fn test_zgemm_strides() {
 }
 
 fn test_gemm_strides<F>() where F: Gemm + Float {
+    if FAST_TEST.is_some() { return; }
+
     for n in 0..20 {
         test_strides::<F>(n, n, n);
     }
 
-    if FAST_TEST.is_none() {
-        for n in (3..12).map(|x| x * 7) {
-            test_strides::<F>(n, n, n);
-        }
+    for n in (3..12).map(|x| x * 7) {
+        test_strides::<F>(n, n, n);
     }
 
     test_strides::<F>(8, 12, 16);
@@ -76,7 +76,10 @@ fn test_gemm_strides<F>() where F: Gemm + Float {
 fn test_gemm<F>() where F: Gemm + Float {
     test_mul_with_id::<F>(4, 4, true);
     test_mul_with_id::<F>(8, 8, true);
-    test_mul_with_id::<F>(32, 32, false);
+    test_mul_with_id::<F>(32, 32, true);
+
+    if FAST_TEST.is_some() { return; }
+
     test_mul_with_id::<F>(128, 128, false);
     test_mul_with_id::<F>(17, 128, false);
     for i in 0..12 {


### PR DESCRIPTION
- Threading is supported in miri, except the num_cpus::get_physical call, which is skipped
- Miri is extremely slow at running the full unoptimized gemm loop unfortunately, any non-trivial matrix sizes are skipped in tests (which is a shame, there are more branches to cover for larger sizes).