### PR TITLE
Fix Miri error with -Zmiri-tag-raw-pointers

### DIFF
--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -12,7 +12,8 @@ rustup default "$MIRI_NIGHTLY"
 rustup component add miri
 cargo miri setup
 
-# disable isolation for num_cpus::get_physical
-MIRIFLAGS=-Zmiri-disable-isolation \
+# Disable isolation for num_cpus::get_physical.
+# Also add flags for additional checks.
+MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-tag-raw-pointers -Zmiri-check-number-validity" \
 MMTEST_FAST_TEST=1 \
     cargo miri test "$@"

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -409,8 +409,8 @@ unsafe fn gemm_packed<K>(nc: usize, kc: usize, mc: usize,
                 // NOTE: For the rust kernels, it performs better to simply
                 // always use the masked kernel function!
                 if K::always_masked() || nr_ < nr || mr_ < mr {
-                    masked_kernel::<_, K>(kc, alpha, &*app.ptr(), &*bpp.ptr(),
-                                          beta, &mut *c.ptr(), rsc, csc,
+                    masked_kernel::<_, K>(kc, alpha, app.ptr(), bpp.ptr(),
+                                          beta, c.ptr(), rsc, csc,
                                           mr_, nr_, mask_buf);
                     continue;
                 } else {


### PR DESCRIPTION
Before this PR, running `MIRIFLAGS="-Zmiri-tag-raw-pointers" cargo miri test` caused Miri to report undefined behavior in the `test_dgemm` test. This PR fixes the underlying issue – Miri doesn't like us using a reference to an element to access other elements.

There may be other Miri errors. Miri takes forever to run, and I haven't waited for it to finish yet.