### PR TITLE
Updated comment in function kernel_x86_avx

### DIFF
--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -274,9 +274,7 @@ unsafe fn kernel_x86_avx<MA>(k: usize, alpha: T, a: *const T, b: *const T,
         // encoded in a nibble (4 bits) total, i.e. 0b1100, had the intrinsics
         // been defined differently. The highest bit in each nibble controls
         // zero-ing behaviour though.
-        // let b_3210 = _mm256_permute2f128_pd(b_1032, b_1032, 0b0000_0011);
-        // 0b0000_0011 = 0x03; makes it clearer which bits we are acting on.
-        let b_3210 = _mm256_permute2f128_pd(b_1032, b_1032, 0x03);
+        let b_3210 = _mm256_permute2f128_pd(b_1032, b_1032, 0b0011);
         let b_2301 = _mm256_shuffle_pd(b_3210, b_3210, 0b0101);
 
         // The ideal distribution of a_i b_j pairs in the resulting panel of

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -263,19 +263,19 @@ unsafe fn kernel_x86_avx<MA>(k: usize, alpha: T, a: *const T, b: *const T,
         //
         // 0 1 2 3 (the original)
         // 1 0 3 2 (chosen because of _mm256_shuffle_pd)
-        // 2 3 0 1 (chosen because of _mm256_permute2f128_pd)
-        // 3 0 1 2 (chosen because of _mm256_shuffle_pd applied after _mm256_permute2f128_pd)
+        // 3 2 1 0 (chosen because of _mm256_permute2f128_pd)
+        // 2 3 0 1 (chosen because of _mm256_shuffle_pd)
         let b_1032 = _mm256_shuffle_pd(b_0123, b_0123, 0b0101);
 
         // Both packed 4-vectors are the same, so one could also perform
-        // the selection 0b0000_0001 or 0b0011_0010.
+        // the selection 0b0000_0001 or 0b0010_0001 or 0b0010_0011.
         // The confusing part is that of the lower 4 bits and upper 4 bits
         // only 2 bits are used in each. The same choice could have been
         // encoded in a nibble (4 bits) total, i.e. 0b1100, had the intrinsics
         // been defined differently. The highest bit in each nibble controls
         // zero-ing behaviour though.
-        // let b_2301 = _mm256_permute2f128_pd(b_0123, b_0123, 0b0011_0000);
-        // 0b0011_0000 = 0x30; makes it clearer which bits we are acting on.
+        // let b_3210 = _mm256_permute2f128_pd(b_1032, b_1032, 0b0000_0011);
+        // 0b0000_0011 = 0x03; makes it clearer which bits we are acting on.
         let b_3210 = _mm256_permute2f128_pd(b_1032, b_1032, 0x03);
         let b_2301 = _mm256_shuffle_pd(b_3210, b_3210, 0b0101);
 


### PR DESCRIPTION
While looking through the code I noticed that a comment describing why certain permutations are done a certain way with intrinsics did not reflect what was actually done in the code. Specifically the permutation set mentioned in the comment was 
{0123, 1032, 2301, 3012} while the actual permutations are {0123, 1032, 3210, 2301}.

In addition the comment mentioned alternative selections that were partly not correct with respect to what the code was actually doing. I updated them and verified the correctness according to [the intel docs](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#ig_expand=6418,5227&techs=AVX,AVX2&cats=Swizzle) as well as [tests on godbolt](https://godbolt.org/z/xn8cWdx38).