### PR TITLE
Silence suspicious Send/Sync impls warning

### DIFF
--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -1,11 +1,19 @@
+// Copyright 2020, 2022 Ulrik Sverdrup "bluss"
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
 
-use core::marker::PhantomData;
+#![allow(unknown_lints, suspicious_auto_trait_impls)]
+
 use rawpointer::PointerExt;
 
 /// A Send + Sync raw pointer wrapper
 #[derive(Copy, Clone)]
 #[repr(transparent)]
-pub(crate) struct Ptr<T> { ptr: T, marker: PhantomData<*const u8> }
+pub(crate) struct Ptr<T> { ptr: T }
 unsafe impl<T> Sync for Ptr<*const T> { }
 unsafe impl<T> Sync for Ptr<*mut T> { }
 unsafe impl<T> Send for Ptr<*const T> { }
@@ -17,7 +25,7 @@ unsafe impl<T> Send for Ptr<*mut T> { }
 ///
 /// Unsafe since it is thread safety critical to use the raw pointer correctly.
 #[allow(non_snake_case)]
-pub(crate) unsafe fn Ptr<T>(ptr: T) -> Ptr<T> { Ptr { ptr, marker: PhantomData } }
+pub(crate) unsafe fn Ptr<T>(ptr: T) -> Ptr<T> { Ptr { ptr } }
 
 impl<T> Ptr<T> {
     /// Get the pointer
@@ -31,7 +39,7 @@ impl<T> Ptr<T> {
 impl<T> Ptr<*mut T> {
     /// Get as *const T
     pub(crate) fn to_const(self) -> Ptr<*const T> {
-        Ptr { ptr: self.ptr, marker: PhantomData }
+        Ptr { ptr: self.ptr }
     }
 }
 


### PR DESCRIPTION
Revisit the previous fix. It's clear that the Ptr code will not change
meaning with the coming breaking change, because it's only ever used
with Ptr<*const T> and Ptr<*mut T> as parameterizations.

For this reason, it's more correct IMO to accept the code meaning
change, which doesn't change the meaning of the crate, by silencing the
warning and not making any unnecessary and ugly changes to the struct
fields.