### PR TITLE
Request only 16-byte alignment on macos

### DIFF
--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -342,8 +342,9 @@ const MASK_BUF_SIZE: usize = KERNEL_MAX_SIZE + KERNEL_MAX_ALIGN - 1;
 
 // Pointers into buffer will be manually aligned anyway, due to
 // bugs we have seen on certain platforms (macos) that look like
-// we don't get aligned allocations out of TLS (?).
-#[repr(align(32))]
+// we don't get more than 16-aligned allocations out of TLS
+#[cfg_attr(not(target_os = "macos"), repr(align(32)))]
+#[cfg_attr(target_os = "macos", repr(align(16)))]
 struct MaskBuffer {
     buffer: [u8; MASK_BUF_SIZE],
 }


### PR DESCRIPTION
As a second fix for the TLS on macos alignment problem, request only 16-byte alignment on macos, because we don't get more.

There's a new debug assertion in std which trips on accessing otherwise, even if it does not really affect us.

Fixes #55 (hopefully)