### PR TITLE
Arm64/AArch64 Neon kernels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,8 @@ jobs:
         include:
           - rust: stable
             target: aarch64-unknown-linux-gnu
+          - rust: 1.61.0
+            target: aarch64-unknown-linux-gnu
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,8 @@ jobs:
             target: aarch64-unknown-linux-gnu
           - rust: 1.61.0
             target: aarch64-unknown-linux-gnu
+          - rust: 1.41.1  # MSRV
+            target: aarch64-unknown-linux-gnu
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ categories = ["science"]
 
 exclude = ["docs/*"]
 
+build = "build.rs"
+
 [lib]
 bench = false
 
@@ -52,6 +54,8 @@ std = []
 # support for compile-time configuration
 constconf = []
 
+[build-dependencies]
+autocfg = "1"
 
 [profile.release]
 debug = true

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -104,11 +104,12 @@ macro_rules! gemm_layout {
             use crate::$gemm;
             $(
 
-            fn base(bench: &mut Bencher, al: Layout, bl: Layout, cl: Layout)
+            fn base(bench: &mut Bencher, al: Layout, bl: Layout, cl: Layout, use_beta: bool)
             {
                 let a = vec![0.; $m * $m];
                 let b = vec![0.; $m * $m];
                 let mut c = vec![0.; $m * $m];
+                let beta = if use_beta { 0.1 } else { 0. };
                 let (rsa, csa) = al.strides($m, 1);
                 let (rsb, csb) = bl.strides($m, 1);
                 let (rsc, csc) = cl.strides($m, 1);
@@ -119,32 +120,50 @@ macro_rules! gemm_layout {
                             1.,
                             a.as_ptr(), rsa, csa,
                             b.as_ptr(), rsb, csb,
-                            0.,
+                            beta,
                             c.as_mut_ptr(), rsc, csc,
                             )
                     }
                 });
             }
 
-            pub fn ccc(bench: &mut Bencher) { base(bench, C, C, C); }
-            pub fn ccf(bench: &mut Bencher) { base(bench, C, C, F); }
-            pub fn fcc(bench: &mut Bencher) { base(bench, F, C, C); }
-            pub fn cfc(bench: &mut Bencher) { base(bench, C, F, C); }
-            pub fn ffc(bench: &mut Bencher) { base(bench, F, F, C); }
-            pub fn cff(bench: &mut Bencher) { base(bench, C, F, F); }
-            pub fn fcf(bench: &mut Bencher) { base(bench, F, C, F); }
-            pub fn fff(bench: &mut Bencher) { base(bench, F, F, F); }
+            pub fn nobeta_ccc(bench: &mut Bencher) { base(bench, C, C, C, false); }
+            pub fn nobeta_ccf(bench: &mut Bencher) { base(bench, C, C, F, false); }
+            pub fn nobeta_fcc(bench: &mut Bencher) { base(bench, F, C, C, false); }
+            pub fn nobeta_cfc(bench: &mut Bencher) { base(bench, C, F, C, false); }
+            pub fn nobeta_ffc(bench: &mut Bencher) { base(bench, F, F, C, false); }
+            pub fn nobeta_cff(bench: &mut Bencher) { base(bench, C, F, F, false); }
+            pub fn nobeta_fcf(bench: &mut Bencher) { base(bench, F, C, F, false); }
+            pub fn nobeta_fff(bench: &mut Bencher) { base(bench, F, F, F, false); }
+
+            pub fn beta_ccc(bench: &mut Bencher) { base(bench, C, C, C, true); }
+            pub fn beta_ccf(bench: &mut Bencher) { base(bench, C, C, F, true); }
+            pub fn beta_fcc(bench: &mut Bencher) { base(bench, F, C, C, true); }
+            pub fn beta_cfc(bench: &mut Bencher) { base(bench, C, F, C, true); }
+            pub fn beta_ffc(bench: &mut Bencher) { base(bench, F, F, C, true); }
+            pub fn beta_cff(bench: &mut Bencher) { base(bench, C, F, F, true); }
+            pub fn beta_fcf(bench: &mut Bencher) { base(bench, F, C, F, true); }
+            pub fn beta_fff(bench: &mut Bencher) { base(bench, F, F, F, true); }
             )+
         }
         benchmark_group!{ $modname,
-            $modname::ccc,
-            $modname::ccf,
-            $modname::fcc,
-            $modname::cfc,
-            $modname::ffc,
-            $modname::cff,
-            $modname::fcf,
-            $modname::fff
+            $modname::nobeta_ccc,
+            $modname::nobeta_ccf,
+            $modname::nobeta_fcc,
+            $modname::nobeta_cfc,
+            $modname::nobeta_ffc,
+            $modname::nobeta_cff,
+            $modname::nobeta_fcf,
+            $modname::nobeta_fff,
+
+            $modname::beta_ccc,
+            $modname::beta_ccf,
+            $modname::beta_fcc,
+            $modname::beta_cfc,
+            $modname::beta_ffc,
+            $modname::beta_cff,
+            $modname::beta_fcf,
+            $modname::beta_fff
         }
     };
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    if std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or(String::new()) == "aarch64" {
+        match autocfg::AutoCfg::new() {
+            // From 1.61 aarch64 intrinsics and #[target_feature]
+            Ok(ac) => if ac.probe_rustc_version(1, 61) {
+                println!("cargo:rustc-cfg=has_aarch64_simd");
+            }
+            Err(err) => println!("cargo:warning={}", err),
+        }
+    }
+}

--- a/spare kernels/aarch64_neon_4x4.rs
+++ b/spare kernels/aarch64_neon_4x4.rs
@@ -1,0 +1,150 @@
+#[cfg(target_arch="aarch64")]
+struct KernelArmNeon;
+
+#[cfg(target_arch="aarch64")]
+impl GemmKernel for KernelArmNeon {
+    type Elem = T;
+
+    type MRTy = U4;
+    type NRTy = U4;
+
+    #[inline(always)]
+    fn align_to() -> usize { 16 }
+
+    #[inline(always)]
+    fn always_masked() -> bool { false }
+
+    #[inline(always)]
+    fn nc() -> usize { archparam::S_NC }
+    #[inline(always)]
+    fn kc() -> usize { archparam::S_KC }
+    #[inline(always)]
+    fn mc() -> usize { archparam::S_MC }
+
+    #[inline(always)]
+    unsafe fn kernel(
+        k: usize,
+        alpha: T,
+        a: *const T,
+        b: *const T,
+        beta: T,
+        c: *mut T, rsc: isize, csc: isize) {
+        kernel_target_arm_neon(k, alpha, a, b, beta, c, rsc, csc)
+    }
+}
+
+// 4x4 neon kernel unrolled developed for apple silicon M1
+#[cfg(target_arch="aarch64")]
+#[target_feature(enable="neon")]
+unsafe fn kernel_target_arm_neon(k: usize, alpha: T, a: *const T, b: *const T,
+                                 beta: T, c: *mut T, rsc: isize, csc: isize)
+{
+    use core::arch::aarch64::*;
+    const MR: usize = KernelArmNeon::MR;
+    const NR: usize = KernelArmNeon::NR;
+
+    let (mut a, mut b, rsc, csc) = if rsc == 1 { (b, a, csc, rsc) } else { (a, b, rsc, csc) };
+
+    let mut ab = [vmovq_n_f32(0.); MR];
+    let mut ab2 = [vmovq_n_f32(0.); MR];
+    let mut ab3 = [vmovq_n_f32(0.); MR];
+    let mut ab4 = [vmovq_n_f32(0.); MR];
+    let use_fma = true;
+
+    // Compute
+    // ab_ij = a_i * b_j for all i, j
+    macro_rules! ab_ij_equals_ai_bj {
+        ($dest:ident, $av:expr, $bv:expr) => {
+            if use_fma {
+                $dest[0] = vfmaq_laneq_f32($dest[0], $bv, $av, 0);
+                $dest[1] = vfmaq_laneq_f32($dest[1], $bv, $av, 1);
+                $dest[2] = vfmaq_laneq_f32($dest[2], $bv, $av, 2);
+                $dest[3] = vfmaq_laneq_f32($dest[3], $bv, $av, 3);
+            } else {
+                $dest[0] = vaddq_f32($dest[0], vmulq_laneq_f32($bv, $av, 0));
+                $dest[1] = vaddq_f32($dest[1], vmulq_laneq_f32($bv, $av, 1));
+                $dest[2] = vaddq_f32($dest[2], vmulq_laneq_f32($bv, $av, 2));
+                $dest[3] = vaddq_f32($dest[3], vmulq_laneq_f32($bv, $av, 3));
+            }
+        }
+    }
+
+    const UNROLL_BY: usize = 4;
+
+    for _ in 0..k / UNROLL_BY {
+        let av = vld1q_f32(a);
+        let bv = vld1q_f32(b);
+        // eprintln!("a: {av:?}");
+        // eprintln!("b: {bv:?}");
+
+        // FMLA instruction
+        // Cortex 7A: FMA has 7 cycles latency or 3 cycles when the dependency is on the accumulator
+        // M1: Latency 3, throughput 0.25
+        ab_ij_equals_ai_bj!(ab, av, bv);
+
+        let av = vld1q_f32(a.add(4));
+        let bv = vld1q_f32(b.add(4));
+
+        ab_ij_equals_ai_bj!(ab2, av, bv);
+
+        if UNROLL_BY > 2 {
+
+        let av = vld1q_f32(a.add(8));
+        let bv = vld1q_f32(b.add(8));
+
+        ab_ij_equals_ai_bj!(ab3, av, bv);
+
+        let av = vld1q_f32(a.add(12));
+        let bv = vld1q_f32(b.add(12));
+
+        ab_ij_equals_ai_bj!(ab4, av, bv);
+
+        }
+
+        a = a.offset(UNROLL_BY as isize * MR as isize);
+        b = b.offset(UNROLL_BY as isize * NR as isize);
+    }
+
+    for _ in 0..k % UNROLL_BY {
+        let av = vld1q_f32(a);
+        let bv = vld1q_f32(b);
+
+        ab_ij_equals_ai_bj!(ab, av, bv);
+
+        a = a.offset(MR as isize);
+        b = b.offset(NR as isize);
+    }
+
+    macro_rules! c {
+        ($i:expr, $j:expr) => (c.offset(rsc * $i as isize + csc * $j as isize));
+    }
+
+    macro_rules! extract {
+        ($v:expr, $imm:expr) => (
+            f32::from_bits(vgetq_lane_u32(core::mem::transmute::<_, uint32x4_t>($v), $imm))
+        )
+    }
+
+    // Combine accumulators and multiply by alpha
+    loop4!(i, ab[i] = vaddq_f32(vaddq_f32(ab[i], ab2[i]), vaddq_f32(ab3[i], ab4[i])));
+    loop4!(i, ab[i] = vmulq_n_f32(ab[i], alpha));
+
+    if beta == 0. {
+        // set C = α A B
+        if csc == 1 {
+            loop4!(i, vst1q_f32(c![i, 0], ab[i]));
+        } else {
+            loop4!(i, vst1q_lane_f32(c![i, 0], ab[i], 0));
+            loop4!(i, vst1q_lane_f32(c![i, 1], ab[i], 1));
+            loop4!(i, vst1q_lane_f32(c![i, 2], ab[i], 2));
+            loop4!(i, vst1q_lane_f32(c![i, 3], ab[i], 3));
+        }
+    } else {
+        // set C = α A B + beta C
+        loop4!(i, *c![i, 0] = *c![i, 0] * beta + extract!(ab[i], 0));
+        loop4!(i, *c![i, 1] = *c![i, 1] * beta + extract!(ab[i], 1));
+        loop4!(i, *c![i, 2] = *c![i, 2] * beta + extract!(ab[i], 2));
+        loop4!(i, *c![i, 3] = *c![i, 3] * beta + extract!(ab[i], 3));
+    }
+}
+

--- a/src/aarch64/macros.rs
+++ b/src/aarch64/macros.rs
@@ -1,11 +1,11 @@
-macro_rules! is_x86_feature_detected_ {
+macro_rules! is_aarch64_feature_detected_ {
     ($name:tt) => {{
         #[cfg(feature="std")]
         {
             // For testing purposes, we can make sure only one specific feature
             // is enabled by setting MMTEST_FEATURE=featurename (all others
             // disabled). This does not force it to be detected, it must also be.
-             compile_env_matches_or_is_empty!("MMTEST_FEATURE", $name) && is_x86_feature_detected!($name)
+             compile_env_matches_or_is_empty!("MMTEST_FEATURE", $name) && std::arch::is_aarch64_feature_detected!($name)
         }
         #[cfg(not(feature="std"))]
         {

--- a/src/aarch64/mod.rs
+++ b/src/aarch64/mod.rs
@@ -1,0 +1,2 @@
+#[macro_use]
+mod macros;

--- a/src/archmacros.rs
+++ b/src/archmacros.rs
@@ -1,0 +1,11 @@
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch="aarch64"))]
+macro_rules! compile_env_matches_or_is_empty {
+    ($envvar:tt, $feature_name:tt) => {
+        (match option_env!($envvar) {
+            None => true,
+            Some(v) => v == $feature_name
+        })
+    }
+}
+

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -27,6 +27,7 @@ struct KernelFma;
 struct KernelSse2;
 
 #[cfg(target_arch="aarch64")]
+#[cfg(has_aarch64_simd)]
 struct KernelNeon;
 
 struct KernelFallback;
@@ -53,6 +54,7 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
     }
 
     #[cfg(target_arch="aarch64")]
+    #[cfg(has_aarch64_simd)]
     {
         if is_aarch64_feature_detected_!("neon") {
             return selector.select(KernelNeon);
@@ -174,6 +176,7 @@ impl GemmKernel for KernelSse2 {
 }
 
 #[cfg(target_arch="aarch64")]
+#[cfg(has_aarch64_simd)]
 impl GemmKernel for KernelNeon {
     type Elem = T;
 
@@ -821,6 +824,7 @@ unsafe fn kernel_x86_avx<MA>(k: usize, alpha: T, a: *const T, b: *const T,
 }
 
 #[cfg(target_arch="aarch64")]
+#[cfg(has_aarch64_simd)]
 #[target_feature(enable="neon")]
 unsafe fn kernel_target_neon(k: usize, alpha: T, a: *const T, b: *const T,
                              beta: T, c: *mut T, rsc: isize, csc: isize)
@@ -1005,6 +1009,7 @@ mod tests {
     }
 
     #[cfg(any(target_arch="aarch64"))]
+    #[cfg(has_aarch64_simd)]
     mod test_kernel_aarch64 {
         use super::test_a_kernel;
         use super::super::*;

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -193,6 +193,10 @@ pub(crate) mod test {
         }
     }
 
+    /// Assert that we can compute A I == A and I B == B for the kernel (truncated, if needed)
+    ///
+    /// Tests C col major and row major
+    /// Tests beta == 0 (and no other option)
     pub(crate) fn test_a_kernel<K, T>(_name: &str)
     where
         K: GemmKernel<Elem = T>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,9 +148,15 @@ mod threading;
 mod aligned_alloc;
 mod util;
 
+#[macro_use]
+mod archmacros;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[macro_use]
 mod x86;
+#[cfg(any(target_arch = "aarch64"))]
+#[macro_use]
+mod aarch64;
+
 mod dgemm_kernel;
 mod sgemm_kernel;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,12 +51,17 @@
 //!   on all targets. These may depend on autovectorization to perform well.
 //!
 //! - *x86* and *x86-64* features can be detected at runtime by default or
-//!   compile time (if enabled), and the crate following kernel variants are
+//!   compile time (if enabled), and the following kernel variants are
 //!   implemented:
 //!
 //!   - `fma`
 //!   - `avx`
 //!   - `sse2`
+//!
+//! - *aarch64* features can be detected at runtime by default or compile time
+//!   (if enabled), and the following kernel variants are implemented:
+//!
+//!   - `neon`
 //!
 //! ## Features
 //!
@@ -116,8 +121,10 @@
 //! This version requires Rust 1.41.1 or later; the crate follows a carefully
 //! considered upgrade policy, where updating the minimum Rust version is not a breaking
 //! change.
+//!
+//! Some features are enabled with later versions: from Rust 1.61 AArch64 NEON support.
 
-#![doc(html_root_url = "https://docs.rs/matrixmultiply/0.2/")]
+#![doc(html_root_url = "https://docs.rs/matrixmultiply/0.3/")]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(feature = "std"))]

--- a/src/loopmacros.rs
+++ b/src/loopmacros.rs
@@ -76,12 +76,21 @@ macro_rules! unroll_by {
 #[cfg(not(debug_assertions))]
 macro_rules! unroll_by {
     ($by:tt => $ntimes:expr, $e:expr) => {{
+        // using while loop to avoid problems
+        // with requiring inlining of foor loop parts
         let k = $ntimes;
-        for _ in 0..k / $by {
+        let mut _index = 0;
+        let _target = k / $by;
+        while _index < _target {
             repeat!($by $e);
+            _index += 1;
         }
-        for _ in 0..k % $by {
-            $e
+
+        let mut _index = 0;
+        let _target = k % $by;
+        while _index < _target {
+            $e;
+            _index += 1;
         }
     }}
 }

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -25,6 +25,7 @@ struct KernelFma;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 struct KernelSse2;
 #[cfg(target_arch="aarch64")]
+#[cfg(has_aarch64_simd)]
 struct KernelNeon;
 struct KernelFallback;
 
@@ -49,6 +50,7 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
         }
     }
     #[cfg(target_arch="aarch64")]
+    #[cfg(has_aarch64_simd)]
     {
         if is_aarch64_feature_detected_!("neon") {
             return selector.select(KernelNeon);
@@ -160,6 +162,7 @@ impl GemmKernel for KernelSse2 {
 
 
 #[cfg(target_arch="aarch64")]
+#[cfg(has_aarch64_simd)]
 impl GemmKernel for KernelNeon {
     type Elem = T;
 
@@ -505,6 +508,7 @@ unsafe fn kernel_x86_avx<MA>(k: usize, alpha: T, a: *const T, b: *const T,
 }
 
 #[cfg(target_arch="aarch64")]
+#[cfg(has_aarch64_simd)]
 #[target_feature(enable="neon")]
 unsafe fn kernel_target_neon(k: usize, alpha: T, a: *const T, b: *const T,
                              beta: T, c: *mut T, rsc: isize, csc: isize)
@@ -693,6 +697,7 @@ mod tests {
     }
 
     #[cfg(any(target_arch="aarch64"))]
+    #[cfg(has_aarch64_simd)]
     mod test_kernel_aarch64 {
         use super::test_a_kernel;
         use super::super::*;

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 - 2018 Ulrik Sverdrup "bluss"
+// Copyright 2016 - 2023 Ulrik Sverdrup "bluss"
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -10,7 +10,6 @@ use crate::kernel::GemmKernel;
 use crate::kernel::GemmSelect;
 use crate::kernel::{U4, U8};
 use crate::archparam;
-
 
 #[cfg(target_arch="x86")]
 use core::arch::x86::*;
@@ -25,6 +24,8 @@ struct KernelAvx;
 struct KernelFma;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 struct KernelSse2;
+#[cfg(target_arch="aarch64")]
+struct KernelNeon;
 struct KernelFallback;
 
 type T = f32;
@@ -47,12 +48,18 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
             return selector.select(KernelSse2);
         }
     }
+    #[cfg(target_arch="aarch64")]
+    {
+        if is_aarch64_feature_detected_!("neon") {
+            return selector.select(KernelNeon);
+        }
+    }
     return selector.select(KernelFallback);
 }
 
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 macro_rules! loop_m { ($i:ident, $e:expr) => { loop8!($i, $e) }; }
-#[cfg(test)]
+#[cfg(all(test, any(target_arch="x86", target_arch="x86_64")))]
 macro_rules! loop_n { ($j:ident, $e:expr) => { loop8!($j, $e) }; }
 
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
@@ -148,6 +155,39 @@ impl GemmKernel for KernelSse2 {
         beta: T,
         c: *mut T, rsc: isize, csc: isize) {
         kernel_target_sse2(k, alpha, a, b, beta, c, rsc, csc)
+    }
+}
+
+
+#[cfg(target_arch="aarch64")]
+impl GemmKernel for KernelNeon {
+    type Elem = T;
+
+    type MRTy = U8;
+    type NRTy = U8;
+
+    #[inline(always)]
+    fn align_to() -> usize { 32 }
+
+    #[inline(always)]
+    fn always_masked() -> bool { false }
+
+    #[inline(always)]
+    fn nc() -> usize { archparam::S_NC }
+    #[inline(always)]
+    fn kc() -> usize { archparam::S_KC }
+    #[inline(always)]
+    fn mc() -> usize { archparam::S_MC }
+
+    #[inline(always)]
+    unsafe fn kernel(
+        k: usize,
+        alpha: T,
+        a: *const T,
+        b: *const T,
+        beta: T,
+        c: *mut T, rsc: isize, csc: isize) {
+        kernel_target_neon(k, alpha, a, b, beta, c, rsc, csc)
     }
 }
 
@@ -464,6 +504,140 @@ unsafe fn kernel_x86_avx<MA>(k: usize, alpha: T, a: *const T, b: *const T,
     }
 }
 
+#[cfg(target_arch="aarch64")]
+#[target_feature(enable="neon")]
+unsafe fn kernel_target_neon(k: usize, alpha: T, a: *const T, b: *const T,
+                             beta: T, c: *mut T, rsc: isize, csc: isize)
+{
+    use core::arch::aarch64::*;
+    const MR: usize = KernelNeon::MR;
+    const NR: usize = KernelNeon::NR;
+
+    let (mut a, mut b, rsc, csc) = if rsc == 1 { (b, a, csc, rsc) } else { (a, b, rsc, csc) };
+
+    // Kernel 8 x 8 (a x b)
+    // Four quadrants of 4 x 4
+    let mut ab11 = [vmovq_n_f32(0.); 4];
+    let mut ab12 = [vmovq_n_f32(0.); 4];
+    let mut ab21 = [vmovq_n_f32(0.); 4];
+    let mut ab22 = [vmovq_n_f32(0.); 4];
+
+    // Compute
+    // ab_ij = a_i * b_j for all i, j
+    macro_rules! ab_ij_equals_ai_bj {
+        ($dest:ident, $av:expr, $bv:expr) => {
+            $dest[0] = vfmaq_laneq_f32($dest[0], $bv, $av, 0);
+            $dest[1] = vfmaq_laneq_f32($dest[1], $bv, $av, 1);
+            $dest[2] = vfmaq_laneq_f32($dest[2], $bv, $av, 2);
+            $dest[3] = vfmaq_laneq_f32($dest[3], $bv, $av, 3);
+        }
+    }
+
+    for _ in 0..k {
+        let a1 = vld1q_f32(a);
+        let b1 = vld1q_f32(b);
+        let a2 = vld1q_f32(a.add(4));
+        let b2 = vld1q_f32(b.add(4));
+
+        // compute an outer product ab = a (*) b in four quadrants ab11, ab12, ab21, ab22
+
+        // ab11: [a1 a2 a3 a4] (*) [b1 b2 b3 b4]
+        // ab11: a1b1 a1b2 a1b3 a1b4
+        //       a2b1 a2b2 a2b3 a2b4
+        //       a3b1 a3b2 a3b3 a3b4
+        //       a4b1 a4b2 a4b3 a4b4
+        //  etc
+        ab_ij_equals_ai_bj!(ab11, a1, b1);
+        ab_ij_equals_ai_bj!(ab12, a1, b2);
+        ab_ij_equals_ai_bj!(ab21, a2, b1);
+        ab_ij_equals_ai_bj!(ab22, a2, b2);
+
+        a = a.add(MR);
+        b = b.add(NR);
+    }
+
+    macro_rules! c {
+        ($i:expr, $j:expr) => (c.offset(rsc * $i as isize + csc * $j as isize));
+    }
+
+    // ab *= alpha
+    loop4!(i, ab11[i] = vmulq_n_f32(ab11[i], alpha));
+    loop4!(i, ab12[i] = vmulq_n_f32(ab12[i], alpha));
+    loop4!(i, ab21[i] = vmulq_n_f32(ab21[i], alpha));
+    loop4!(i, ab22[i] = vmulq_n_f32(ab22[i], alpha));
+
+    // load one float32x4_t from four pointers
+    macro_rules! loadq_from_pointers {
+        ($p0:expr, $p1:expr, $p2:expr, $p3:expr) => (
+            {
+                let v = vld1q_dup_f32($p0);
+                let v = vld1q_lane_f32($p1, v, 1);
+                let v = vld1q_lane_f32($p2, v, 2);
+                let v = vld1q_lane_f32($p3, v, 3);
+                v
+            }
+        );
+    }
+
+    if beta != 0. {
+        // load existing value in C
+        let mut c11 = [vmovq_n_f32(0.); 4];
+        let mut c12 = [vmovq_n_f32(0.); 4];
+        let mut c21 = [vmovq_n_f32(0.); 4];
+        let mut c22 = [vmovq_n_f32(0.); 4];
+
+        if csc == 1 {
+            loop4!(i, c11[i] = vld1q_f32(c![i + 0, 0]));
+            loop4!(i, c12[i] = vld1q_f32(c![i + 0, 4]));
+            loop4!(i, c21[i] = vld1q_f32(c![i + 4, 0]));
+            loop4!(i, c22[i] = vld1q_f32(c![i + 4, 4]));
+        } else {
+            loop4!(i, c11[i] = loadq_from_pointers!(c![i + 0, 0], c![i + 0, 1], c![i + 0, 2], c![i + 0, 3]));
+            loop4!(i, c12[i] = loadq_from_pointers!(c![i + 0, 4], c![i + 0, 5], c![i + 0, 6], c![i + 0, 7]));
+            loop4!(i, c21[i] = loadq_from_pointers!(c![i + 4, 0], c![i + 4, 1], c![i + 4, 2], c![i + 4, 3]));
+            loop4!(i, c22[i] = loadq_from_pointers!(c![i + 4, 4], c![i + 4, 5], c![i + 4, 6], c![i + 4, 7]));
+        }
+
+        let betav = vmovq_n_f32(beta);
+
+        // ab += β C
+        loop4!(i, ab11[i] = vfmaq_f32(ab11[i], c11[i], betav));
+        loop4!(i, ab12[i] = vfmaq_f32(ab12[i], c12[i], betav));
+        loop4!(i, ab21[i] = vfmaq_f32(ab21[i], c21[i], betav));
+        loop4!(i, ab22[i] = vfmaq_f32(ab22[i], c22[i], betav));
+    }
+
+    // c <- ab
+    // which is in full
+    //   C <- α A B (+ β C)
+    if csc == 1 {
+        loop4!(i, vst1q_f32(c![i + 0, 0], ab11[i]));
+        loop4!(i, vst1q_f32(c![i + 0, 4], ab12[i]));
+        loop4!(i, vst1q_f32(c![i + 4, 0], ab21[i]));
+        loop4!(i, vst1q_f32(c![i + 4, 4], ab22[i]));
+    } else {
+        loop4!(i, vst1q_lane_f32(c![i + 0, 0], ab11[i], 0));
+        loop4!(i, vst1q_lane_f32(c![i + 0, 1], ab11[i], 1));
+        loop4!(i, vst1q_lane_f32(c![i + 0, 2], ab11[i], 2));
+        loop4!(i, vst1q_lane_f32(c![i + 0, 3], ab11[i], 3));
+
+        loop4!(i, vst1q_lane_f32(c![i + 0, 4], ab12[i], 0));
+        loop4!(i, vst1q_lane_f32(c![i + 0, 5], ab12[i], 1));
+        loop4!(i, vst1q_lane_f32(c![i + 0, 6], ab12[i], 2));
+        loop4!(i, vst1q_lane_f32(c![i + 0, 7], ab12[i], 3));
+
+        loop4!(i, vst1q_lane_f32(c![i + 4, 0], ab21[i], 0));
+        loop4!(i, vst1q_lane_f32(c![i + 4, 1], ab21[i], 1));
+        loop4!(i, vst1q_lane_f32(c![i + 4, 2], ab21[i], 2));
+        loop4!(i, vst1q_lane_f32(c![i + 4, 3], ab21[i], 3));
+
+        loop4!(i, vst1q_lane_f32(c![i + 4, 4], ab22[i], 0));
+        loop4!(i, vst1q_lane_f32(c![i + 4, 5], ab22[i], 1));
+        loop4!(i, vst1q_lane_f32(c![i + 4, 6], ab22[i], 2));
+        loop4!(i, vst1q_lane_f32(c![i + 4, 7], ab22[i], 3));
+    }
+}
+
 #[inline]
 unsafe fn kernel_fallback_impl(k: usize, alpha: T, a: *const T, b: *const T,
                                beta: T, c: *mut T, rsc: isize, csc: isize)
@@ -518,12 +692,41 @@ mod tests {
         }
     }
 
-    #[cfg(any(target_arch="x86", target_arch="x86_64"))]
-    mod test_arch_kernels {
+    #[cfg(any(target_arch="aarch64"))]
+    mod test_kernel_aarch64 {
         use super::test_a_kernel;
         use super::super::*;
         #[cfg(feature = "std")]
         use std::println;
+
+        macro_rules! test_arch_kernels_aarch64 {
+            ($($feature_name:tt, $name:ident, $kernel_ty:ty),*) => {
+                $(
+                #[test]
+                fn $name() {
+                    if is_aarch64_feature_detected_!($feature_name) {
+                        test_a_kernel::<$kernel_ty, _>(stringify!($name));
+                    } else {
+                        #[cfg(feature = "std")]
+                        println!("Skipping, host does not have feature: {:?}", $feature_name);
+                    }
+                }
+                )*
+            }
+        }
+
+        test_arch_kernels_aarch64! {
+            "neon", neon8x8, KernelNeon
+        }
+    }
+
+    #[cfg(any(target_arch="x86", target_arch="x86_64"))]
+    mod test_kernel_x86 {
+        use super::test_a_kernel;
+        use super::super::*;
+        #[cfg(feature = "std")]
+        use std::println;
+
         macro_rules! test_arch_kernels_x86 {
             ($($feature_name:tt, $name:ident, $kernel_ty:ty),*) => {
                 $(

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -126,7 +126,7 @@ impl LoopThreadConfig {
         let size_factor = m * k + k * n;
         let thread_factor = 1 << 14;
         // pure guesswork in terms of what the default should be
-        let arch_factor = if cfg!(any(target_arch="arm", target_arch="aarch64")) {
+        let arch_factor = if cfg!(target_arch="arm") {
             20
         } else {
             1

--- a/tests/sgemm.rs
+++ b/tests/sgemm.rs
@@ -471,6 +471,9 @@ where
                  maximal, rel_diff_max, n_diffs);
     }
 
+    eprintln!("c1: {:?}, {}, {}", c1, rs_c1, cs_c1);
+    eprintln!("c2: {:?}, {}, {}", c2, rs_c2, cs_c2);
+
     if exact {
         assert_eq!(0, n_diffs,
                    "C1 == C2 assertion failed for matrix of size {}x{} with first failing element at index={:?}",


### PR DESCRIPTION
Implement

* 8x8 sgemm kernel for AArch64 using NEON instructions
* 8x4 dgemm kernel for AArch64 using NEON instructions

**Benchmarks (single thread)**

Using benches/benchloop.py in the repository.
on Apple Silicon M1 (MacBookAir10,1 3.2 GHz) 

* sgemm 96.4 gflop/s at M,N,K = 1024
* dgemm 45.8 gflop/s at M,N,K = 1024

Not revolutionary, comparable (for sgemm) with openblas. (Apple Accelerate uses other proprietary extensions which are miles ahead.)

AArch64 NEON has 32 registers, each 128-bit, corresponding being able to store 128 x f32 or 64 x f64. To keep the whole kernel in memory, the upper limit of kernel size would be somewhere below 16x8 for f32.
Further kernel size and NC, KC, MC tweaks can give further benefits here (less significant compared to the already won performance), this PR is a start.