### PR TITLE
Special packing for complex, specialize packing for avx2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,10 +123,13 @@ jobs:
         include:
           - rust: stable
             target: aarch64-unknown-linux-gnu
+            features: constconf cgemm threading
           - rust: 1.61.0
             target: aarch64-unknown-linux-gnu
+            features: cgemm
           - rust: 1.41.1  # MSRV
             target: aarch64-unknown-linux-gnu
+            features: cgemm
 
     steps:
       - uses: actions/checkout@v2
@@ -146,7 +149,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: cargo install cross
       - name: Tests
-        run: cross test --target "${{ matrix.target }}"
+        run: cross test --target "${{ matrix.target }}" --features "${{ matrix.features }}"
         env:
           MMTEST_FAST_TEST: 1
           RUSTFLAGS: -Copt-level=2

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -13,7 +13,6 @@ rustup component add miri
 cargo miri setup
 
 # Disable isolation for num_cpus::get_physical.
-# Also add flags for additional checks.
-MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-tag-raw-pointers -Zmiri-check-number-validity" \
+MIRIFLAGS="-Zmiri-disable-isolation" \
 MMTEST_FAST_TEST=1 \
     cargo miri test "$@"

--- a/src/cgemm_common.rs
+++ b/src/cgemm_common.rs
@@ -1,10 +1,18 @@
-// Copyright 2021 Ulrik Sverdrup "bluss"
+// Copyright 2021-2023 Ulrik Sverdrup "bluss"
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
+use std::mem;
+use std::ptr::copy_nonoverlapping;
+
+use rawpointer::PointerExt;
+
+use crate::kernel::Element;
+use crate::kernel::ConstNum;
 
 // kernel fallback impl macro
 // Depends on a couple of macro and function defitions to be in scope - loop_m/_n, at, etc.
@@ -25,35 +33,38 @@ macro_rules! kernel_fallback_impl_complex {
         let mut ss  = [<$real_ty>::zero(); NR];
 
         let mut ab: [[$elem_ty; NR]; MR] = [[<$elem_ty>::zero(); NR]; MR];
-        let mut a = a;
-        let mut b = b;
+        let mut areal = a as *const $real_ty;
+        let mut breal = b as *const $real_ty;
 
-        // Compute A B into ab[i][j]
         unroll_by!($unroll => k, {
-            // We set
-            //
+            // We set:
             // P + Q i = A
             // R + S i = B
-            loop_m!(i, pp[i] = at(a, i)[0]);
-            loop_m!(i, qq[i] = at(a, i)[1]);
-            loop_n!(i, rr[i] = at(b, i)[0]);
-            loop_n!(i, ss[i] = at(b, i)[1]);
+            //
+            // see pack_complex for how data is packed
+            let aimag = areal.add(MR);
+            let bimag = breal.add(NR);
 
-            loop_m!(i, loop_n!(j, {
-                ab[i][j][0] += pp[i] * rr[j];
-            }));
-            loop_m!(i, loop_n!(j, {
-                ab[i][j][1] += pp[i] * ss[j];
-            }));
-            loop_m!(i, loop_n!(j, {
-                ab[i][j][0] -= qq[i] * ss[j];
-            }));
-            loop_m!(i, loop_n!(j, {
-                ab[i][j][1] += qq[i] * rr[j];
-            }));
+            // AB = PR - QS + i (QR + PS)
+            loop_m!(i, {
+                pp[i] = at(areal, i);
+                qq[i] = at(aimag, i);
+            });
+            loop_n!(j, {
+                rr[j] = at(breal, j);
+                ss[j] = at(bimag, j);
+            });
+            loop_m!(i, {
+                loop_n!(j, {
+                    ab[i][j][0] += pp[i] * rr[j];
+                    ab[i][j][1] += pp[i] * ss[j];
+                    ab[i][j][0] -= qq[i] * ss[j];
+                    ab[i][j][1] += qq[i] * rr[j];
+                })
+            });
 
-            a = a.offset(MR as isize);
-            b = b.offset(NR as isize);
+            areal = aimag.add(MR);
+            breal = bimag.add(NR);
         });
 
         macro_rules! c {
@@ -64,4 +75,107 @@ macro_rules! kernel_fallback_impl_complex {
         loop_n!(j, loop_m!(i, *c![i, j] = mul(alpha, ab[i][j])));
     }
     };
+}
+
+/// GemmKernel packing trait methods
+macro_rules! pack_methods {
+    () => {
+        #[inline]
+        unsafe fn pack_mr(kc: usize, mc: usize, pack: &mut [Self::Elem],
+                          a: *const Self::Elem, rsa: isize, csa: isize)
+        {
+            pack_complex::<Self::MRTy, T, TReal>(kc, mc, pack, a, rsa, csa)
+        }
+
+        #[inline]
+        unsafe fn pack_nr(kc: usize, mc: usize, pack: &mut [Self::Elem],
+                        a: *const Self::Elem, rsa: isize, csa: isize)
+        {
+            pack_complex::<Self::NRTy, T, TReal>(kc, mc, pack, a, rsa, csa)
+        }
+    }
+}
+
+
+/// Pack complex: similar to general packing but separate rows for real and imag parts.
+///
+/// Source matrix contains [p0 + q0i, p1 + q1i, p2 + q2i, ..] and it's packed into
+/// alternate rows of real and imaginary parts.
+///
+/// [ p0 p1 p2 p3 .. (MR repeats)
+///   q0 q1 q2 q3 .. (MR repeats)
+///   px p_ p_ p_ .. (x = MR)
+///   qx q_ q_ q_ .. (x = MR)
+///   py p_ p_ p_ .. (y = 2 * MR)
+///   qy q_ q_ q_ .. (y = 2 * MR)
+///   ...
+/// ]
+pub(crate) unsafe fn pack_complex<MR, T, TReal>(kc: usize, mc: usize, pack: &mut [T],
+                                                a: *const T, rsa: isize, csa: isize)
+    where MR: ConstNum,
+          T: Element,
+          TReal: Element,
+{
+    // use pointers as pointer to TReal
+    let pack = pack.as_mut_ptr() as *mut TReal;
+    let areal = a as *const TReal;
+    let aimag = areal.add(1);
+
+    assert_eq!(mem::size_of::<T>(), 2 * mem::size_of::<TReal>());
+
+    let mr = MR::VALUE;
+    let mut p = 0; // offset into pack
+
+    // general layout case (no contig case when stride != 1)
+    for ir in 0..mc/mr {
+        let row_offset = ir * mr;
+        for j in 0..kc {
+            // real row
+            for i in 0..mr {
+                let a_elt = areal.stride_offset(2 * rsa, i + row_offset)
+                                 .stride_offset(2 * csa, j);
+                copy_nonoverlapping(a_elt, pack.add(p), 1);
+                p += 1;
+            }
+            // imag row
+            for i in 0..mr {
+                let a_elt = aimag.stride_offset(2 * rsa, i + row_offset)
+                                 .stride_offset(2 * csa, j);
+                copy_nonoverlapping(a_elt, pack.add(p), 1);
+                p += 1;
+            }
+        }
+    }
+
+    let zero = TReal::zero();
+
+    // Pad with zeros to multiple of kernel size (uneven mc)
+    let rest = mc % mr;
+    if rest > 0 {
+        let row_offset = (mc/mr) * mr;
+        for j in 0..kc {
+            // real row
+            for i in 0..mr {
+                if i < rest {
+                    let a_elt = areal.stride_offset(2 * rsa, i + row_offset)
+                                     .stride_offset(2 * csa, j);
+                    copy_nonoverlapping(a_elt, pack.add(p), 1);
+                } else {
+                    *pack.add(p) = zero;
+                }
+                p += 1;
+            }
+            // imag row
+            for i in 0..mr {
+                if i < rest {
+                    let a_elt = aimag.stride_offset(2 * rsa, i + row_offset)
+                                     .stride_offset(2 * csa, j);
+                    copy_nonoverlapping(a_elt, pack.add(p), 1);
+                } else {
+                    *pack.add(p) = zero;
+                }
+                p += 1;
+            }
+        }
+    }
 }

--- a/src/cgemm_kernel.rs
+++ b/src/cgemm_kernel.rs
@@ -10,11 +10,11 @@ use crate::kernel::GemmKernel;
 use crate::kernel::GemmSelect;
 use crate::kernel::{U2, U4, c32, Element, c32_mul as mul};
 use crate::archparam;
+use crate::cgemm_common::pack_complex;
 
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 struct KernelFma;
-#[cfg(any(target_arch="x86", target_arch="x86_64"))]
-struct KernelSse2;
+
 struct KernelFallback;
 
 type T = c32;
@@ -32,8 +32,6 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
     {
         if is_x86_feature_detected_!("fma") {
             return selector.select(KernelFma);
-        } else if is_x86_feature_detected_!("sse2") {
-            return selector.select(KernelSse2);
         }
     }
     return selector.select(KernelFallback);
@@ -41,7 +39,6 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
 
 macro_rules! loop_m { ($i:ident, $e:expr) => { loop4!($i, $e) }; }
 macro_rules! loop_n { ($j:ident, $e:expr) => { loop2!($j, $e) }; }
-
 
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 impl GemmKernel for KernelFma {
@@ -63,6 +60,8 @@ impl GemmKernel for KernelFma {
     #[inline(always)]
     fn mc() -> usize { archparam::C_MC }
 
+    pack_methods!{}
+
     #[inline(always)]
     unsafe fn kernel(
         k: usize,
@@ -72,38 +71,6 @@ impl GemmKernel for KernelFma {
         beta: T,
         c: *mut T, rsc: isize, csc: isize) {
         kernel_target_fma(k, alpha, a, b, beta, c, rsc, csc)
-    }
-}
-
-#[cfg(any(target_arch="x86", target_arch="x86_64"))]
-impl GemmKernel for KernelSse2 {
-    type Elem = T;
-
-    type MRTy = <KernelFallback as GemmKernel>::MRTy;
-    type NRTy = <KernelFallback as GemmKernel>::NRTy;
-
-    #[inline(always)]
-    fn align_to() -> usize { 16 }
-
-    #[inline(always)]
-    fn always_masked() -> bool { KernelFallback::always_masked() }
-
-    #[inline(always)]
-    fn nc() -> usize { archparam::C_NC }
-    #[inline(always)]
-    fn kc() -> usize { archparam::C_KC }
-    #[inline(always)]
-    fn mc() -> usize { archparam::C_MC }
-
-    #[inline(always)]
-    unsafe fn kernel(
-        k: usize,
-        alpha: T,
-        a: *const T,
-        b: *const T,
-        beta: T,
-        c: *mut T, rsc: isize, csc: isize) {
-        kernel_target_sse2(k, alpha, a, b, beta, c, rsc, csc)
     }
 }
 
@@ -126,6 +93,8 @@ impl GemmKernel for KernelFallback {
     #[inline(always)]
     fn mc() -> usize { archparam::C_MC }
 
+    pack_methods!{}
+
     #[inline(always)]
     unsafe fn kernel(
         k: usize,
@@ -138,53 +107,33 @@ impl GemmKernel for KernelFallback {
     }
 }
 
+
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 kernel_fallback_impl_complex! {
     // instantiate fma separately to use an unroll count that works better here
-    [inline target_feature(enable="fma")] kernel_target_fma, T, TReal, KernelFallback::MR, KernelFallback::NR, 1
+    [inline target_feature(enable="fma")] kernel_target_fma, T, TReal, KernelFallback::MR, KernelFallback::NR, 2
 }
 
-#[inline]
-#[cfg(any(target_arch="x86", target_arch="x86_64"))]
-#[target_feature(enable="sse2")]
-unsafe fn kernel_target_sse2(k: usize, alpha: T, a: *const T, b: *const T,
-                             beta: T, c: *mut T, rsc: isize, csc: isize)
-{
-    kernel_fallback_impl(k, alpha, a, b, beta, c, rsc, csc)
-}
-
-kernel_fallback_impl_complex! { [inline(always)] kernel_fallback_impl, T, TReal, KernelFallback::MR, KernelFallback::NR, 2 }
+kernel_fallback_impl_complex! { [inline(always)] kernel_fallback_impl, T, TReal, KernelFallback::MR, KernelFallback::NR, 1 }
 
 #[inline(always)]
-unsafe fn at(ptr: *const T, i: usize) -> T {
-    *ptr.offset(i as isize)
+unsafe fn at(ptr: *const TReal, i: usize) -> TReal {
+    *ptr.add(i)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::kernel::test::test_a_kernel;
+    use crate::kernel::test::test_complex_packed_kernel;
 
     #[test]
     fn test_kernel_fallback_impl() {
-        test_a_kernel::<KernelFallback, _>("kernel");
-    }
-
-    #[cfg(any(target_arch="x86", target_arch="x86_64"))]
-    #[test]
-    fn test_loop_m_n() {
-        let mut m = [[0; KernelSse2::NR]; KernelSse2::MR];
-        loop_m!(i, loop_n!(j, m[i][j] += 1));
-        for arr in &m[..] {
-            for elt in &arr[..] {
-                assert_eq!(*elt, 1);
-            }
-        }
+        test_complex_packed_kernel::<KernelFallback, _, TReal>("kernel");
     }
 
     #[cfg(any(target_arch="x86", target_arch="x86_64"))]
     mod test_arch_kernels {
-        use super::test_a_kernel;
+        use super::test_complex_packed_kernel;
         use super::super::*;
         #[cfg(feature = "std")]
         use std::println;
@@ -194,7 +143,7 @@ mod tests {
                 #[test]
                 fn $name() {
                     if is_x86_feature_detected_!($feature_name) {
-                        test_a_kernel::<$kernel_ty, _>(stringify!($name));
+                        test_complex_packed_kernel::<$kernel_ty, _, TReal>(stringify!($name));
                     } else {
                         #[cfg(feature = "std")]
                         println!("Skipping, host does not have feature: {:?}", $feature_name);
@@ -205,8 +154,7 @@ mod tests {
         }
 
         test_arch_kernels_x86! {
-            "fma", fma, KernelFma,
-            "sse2", sse2, KernelSse2
+            "fma", fma, KernelFma
         }
     }
 }

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -22,6 +22,8 @@ use crate::x86::{FusedMulAdd, AvxMulAdd, DMultiplyAdd};
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 struct KernelAvx;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
+struct KernelFmaAvx2;
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
 struct KernelFma;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 struct KernelSse2;
@@ -45,6 +47,9 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
     #[cfg(any(target_arch="x86", target_arch="x86_64"))]
     {
         if is_x86_feature_detected_!("fma") {
+            if is_x86_feature_detected_!("avx2") {
+                return selector.select(KernelFmaAvx2);
+            }
             return selector.select(KernelFma);
         } else if is_x86_feature_detected_!("avx") {
             return selector.select(KernelAvx);
@@ -124,6 +129,58 @@ impl GemmKernel for KernelFma {
     fn kc() -> usize { archparam::D_KC }
     #[inline(always)]
     fn mc() -> usize { archparam::D_MC }
+
+    #[inline(always)]
+    unsafe fn kernel(
+        k: usize,
+        alpha: T,
+        a: *const T,
+        b: *const T,
+        beta: T,
+        c: *mut T,
+        rsc: isize,
+        csc: isize)
+    {
+        kernel_target_fma(k, alpha, a, b, beta, c, rsc, csc)
+    }
+}
+
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+impl GemmKernel for KernelFmaAvx2 {
+    type Elem = T;
+
+    type MRTy = <KernelAvx as GemmKernel>::MRTy;
+    type NRTy = <KernelAvx as GemmKernel>::NRTy;
+
+    #[inline(always)]
+    fn align_to() -> usize { KernelAvx::align_to() }
+
+    #[inline(always)]
+    fn always_masked() -> bool { KernelAvx::always_masked() }
+
+    #[inline(always)]
+    fn nc() -> usize { archparam::D_NC }
+    #[inline(always)]
+    fn kc() -> usize { archparam::D_KC }
+    #[inline(always)]
+    fn mc() -> usize { archparam::D_MC }
+
+    #[inline]
+    unsafe fn pack_mr(kc: usize, mc: usize, pack: &mut [Self::Elem],
+                      a: *const Self::Elem, rsa: isize, csa: isize)
+    {
+        // safety: Avx2 is enabled
+        crate::packing::pack_avx2::<Self::MRTy, T>(kc, mc, pack, a, rsa, csa)
+    }
+
+    #[inline]
+    unsafe fn pack_nr(kc: usize, mc: usize, pack: &mut [Self::Elem],
+                      a: *const Self::Elem, rsa: isize, csa: isize)
+    {
+        // safety: Avx2 is enabled
+        crate::packing::pack_avx2::<Self::NRTy, T>(kc, mc, pack, a, rsa, csa)
+    }
+
 
     #[inline(always)]
     unsafe fn kernel(

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use crate::archparam;
+use crate::packing::pack;
 
 /// General matrix multiply kernel
 pub(crate) trait GemmKernel {
@@ -34,6 +35,33 @@ pub(crate) trait GemmKernel {
     fn kc() -> usize { archparam::S_KC }
     #[inline(always)]
     fn mc() -> usize { archparam::S_MC }
+
+    /// Pack matrix A into its packing buffer.
+    ///
+    /// See pack for more documentation.
+    ///
+    /// Override only if the default packing function does not
+    /// use the right layout.
+    #[inline]
+    unsafe fn pack_mr(kc: usize, mc: usize, pack_buf: &mut [Self::Elem],
+                      a: *const Self::Elem, rsa: isize, csa: isize)
+    {
+        pack::<Self::MRTy, _>(kc, mc, pack_buf, a, rsa, csa)
+    }
+
+    /// Pack matrix B into its packing buffer
+    ///
+    /// See pack for more documentation.
+    ///
+    /// Override only if the default packing function does not
+    /// use the right layout.
+    #[inline]
+    unsafe fn pack_nr(kc: usize, mc: usize, pack_buf: &mut [Self::Elem],
+                      a: *const Self::Elem, rsa: isize, csa: isize)
+    {
+        pack::<Self::NRTy, _>(kc, mc, pack_buf, a, rsa, csa)
+    }
+
 
     /// Matrix multiplication kernel
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,7 @@ pub(crate) use archparam_defaults as archparam;
 
 mod gemm;
 mod kernel;
+mod packing;
 mod ptr;
 mod threading;
 

--- a/src/packing.rs
+++ b/src/packing.rs
@@ -1,0 +1,85 @@
+// Copyright 2016 - 2023 Ulrik Sverdrup "bluss"
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use rawpointer::PointerExt;
+
+use core::ptr::copy_nonoverlapping;
+
+use crate::kernel::ConstNum;
+use crate::kernel::Element;
+
+/// Pack matrix into `pack`
+///
+/// + kc: length of the micropanel
+/// + mc: number of rows/columns in the matrix to be packed
+/// + pack: packing buffer
+/// + a: matrix,
+/// + rsa: row stride
+/// + csa: column stride
+///
+/// + MR: kernel rows/columns that we round up to
+// If one of pack and a is of a reference type, it gets a noalias annotation which
+// gives benefits to optimization. The packing buffer is contiguous so it can be passed as a slice
+// here.
+pub(crate) unsafe fn pack<MR, T>(kc: usize, mc: usize, pack: &mut [T],
+                                 a: *const T, rsa: isize, csa: isize)
+    where T: Element,
+          MR: ConstNum,
+{
+    let pack = pack.as_mut_ptr();
+    let mr = MR::VALUE;
+    let mut p = 0; // offset into pack
+
+    if rsa == 1 {
+        // if the matrix is contiguous in the same direction we are packing,
+        // copy a kernel row at a time.
+        for ir in 0..mc/mr {
+            let row_offset = ir * mr;
+            for j in 0..kc {
+                let a_row = a.stride_offset(rsa, row_offset)
+                             .stride_offset(csa, j);
+                copy_nonoverlapping(a_row, pack.add(p), mr);
+                p += mr;
+            }
+        }
+    } else {
+        // general layout case
+        for ir in 0..mc/mr {
+            let row_offset = ir * mr;
+            for j in 0..kc {
+                for i in 0..mr {
+                    let a_elt = a.stride_offset(rsa, i + row_offset)
+                                 .stride_offset(csa, j);
+                    copy_nonoverlapping(a_elt, pack.add(p), 1);
+                    p += 1;
+                }
+            }
+        }
+    }
+
+    let zero = <_>::zero();
+
+    // Pad with zeros to multiple of kernel size (uneven mc)
+    let rest = mc % mr;
+    if rest > 0 {
+        let row_offset = (mc/mr) * mr;
+        for j in 0..kc {
+            for i in 0..mr {
+                if i < rest {
+                    let a_elt = a.stride_offset(rsa, i + row_offset)
+                                 .stride_offset(csa, j);
+                    copy_nonoverlapping(a_elt, pack.add(p), 1);
+                } else {
+                    *pack.add(p) = zero;
+                }
+                p += 1;
+            }
+        }
+    }
+}
+

--- a/src/packing.rs
+++ b/src/packing.rs
@@ -31,6 +31,30 @@ pub(crate) unsafe fn pack<MR, T>(kc: usize, mc: usize, pack: &mut [T],
     where T: Element,
           MR: ConstNum,
 {
+    pack_impl::<MR, T>(kc, mc, pack, a, rsa, csa)
+}
+
+/// Specialized for AVX2
+/// Safety: Requires AVX2
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+#[target_feature(enable="avx2")]
+pub(crate) unsafe fn pack_avx2<MR, T>(kc: usize, mc: usize, pack: &mut [T],
+                                     a: *const T, rsa: isize, csa: isize)
+    where T: Element,
+          MR: ConstNum,
+{
+    pack_impl::<MR, T>(kc, mc, pack, a, rsa, csa)
+}
+
+/// Pack implementation, see pack above for docs.
+///
+/// Uses inline(always) so that it can be instantiated for different target features.
+#[inline(always)]
+unsafe fn pack_impl<MR, T>(kc: usize, mc: usize, pack: &mut [T],
+                           a: *const T, rsa: isize, csa: isize)
+    where T: Element,
+          MR: ConstNum,
+{
     let pack = pack.as_mut_ptr();
     let mr = MR::VALUE;
     let mut p = 0; // offset into pack

--- a/src/zgemm_kernel.rs
+++ b/src/zgemm_kernel.rs
@@ -149,18 +149,21 @@ impl GemmKernel for KernelFallback {
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 kernel_fallback_impl_complex! {
     // instantiate fma separately
-    [inline target_feature(enable="fma") target_feature(enable="avx2")]
+    [inline target_feature(enable="fma") target_feature(enable="avx2")] [fma_yes]
     kernel_target_avx2, T, TReal, KernelAvx2::MR, KernelAvx2::NR, 4
 }
 
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 kernel_fallback_impl_complex! {
     // instantiate fma separately
-    [inline target_feature(enable="fma")]
+    [inline target_feature(enable="fma")] [fma_no]
     kernel_target_fma, T, TReal, KernelFma::MR, KernelFma::NR, 2
 }
 
-kernel_fallback_impl_complex! { [inline] kernel_fallback_impl, T, TReal, KernelFallback::MR, KernelFallback::NR, 1 }
+kernel_fallback_impl_complex! {
+    [inline] [fma_no]
+    kernel_fallback_impl, T, TReal, KernelFallback::MR, KernelFallback::NR, 1
+}
 
 #[inline(always)]
 unsafe fn at(ptr: *const TReal, i: usize) -> TReal {

--- a/src/zgemm_kernel.rs
+++ b/src/zgemm_kernel.rs
@@ -17,6 +17,10 @@ struct KernelAvx2;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 struct KernelFma;
 
+#[cfg(target_arch = "aarch64")]
+#[cfg(has_aarch64_simd)]
+struct KernelNeon;
+
 struct KernelFallback;
 
 type T = c64;
@@ -37,6 +41,13 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
                 return selector.select(KernelAvx2);
             }
             return selector.select(KernelFma);
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    #[cfg(has_aarch64_simd)]
+    {
+        if is_aarch64_feature_detected_!("neon") {
+            return selector.select(KernelNeon);
         }
     }
     return selector.select(KernelFallback);
@@ -113,6 +124,41 @@ impl GemmKernel for KernelFma {
     }
 }
 
+#[cfg(target_arch = "aarch64")]
+#[cfg(has_aarch64_simd)]
+impl GemmKernel for KernelNeon {
+    type Elem = T;
+
+    type MRTy = U4;
+    type NRTy = U2;
+
+    #[inline(always)]
+    fn align_to() -> usize { 16 }
+
+    #[inline(always)]
+    fn always_masked() -> bool { KernelFallback::always_masked() }
+
+    #[inline(always)]
+    fn nc() -> usize { archparam::Z_NC }
+    #[inline(always)]
+    fn kc() -> usize { archparam::Z_KC }
+    #[inline(always)]
+    fn mc() -> usize { archparam::Z_MC }
+
+    pack_methods!{}
+
+    #[inline(always)]
+    unsafe fn kernel(
+        k: usize,
+        alpha: T,
+        a: *const T,
+        b: *const T,
+        beta: T,
+        c: *mut T, rsc: isize, csc: isize) {
+        kernel_target_neon(k, alpha, a, b, beta, c, rsc, csc)
+    }
+}
+
 impl GemmKernel for KernelFallback {
     type Elem = T;
 
@@ -160,6 +206,17 @@ kernel_fallback_impl_complex! {
     kernel_target_fma, T, TReal, KernelFma::MR, KernelFma::NR, 2
 }
 
+// Kernel neon
+
+#[cfg(target_arch = "aarch64")]
+#[cfg(has_aarch64_simd)]
+kernel_fallback_impl_complex! {
+    [inline target_feature(enable="neon")] [fma_yes]
+    kernel_target_neon, T, TReal, KernelNeon::MR, KernelNeon::NR, 1
+}
+
+// kernel fallback
+
 kernel_fallback_impl_complex! {
     [inline] [fma_no]
     kernel_fallback_impl, T, TReal, KernelFallback::MR, KernelFallback::NR, 1
@@ -178,6 +235,34 @@ mod tests {
     #[test]
     fn test_kernel_fallback_impl() {
         test_complex_packed_kernel::<KernelFallback, _, TReal>("kernel");
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[cfg(has_aarch64_simd)]
+    mod test_kernel_aarch64 {
+        use super::test_complex_packed_kernel;
+        use super::super::*;
+        #[cfg(feature = "std")]
+        use std::println;
+        macro_rules! test_arch_kernels {
+            ($($feature_name:tt, $name:ident, $kernel_ty:ty),*) => {
+                $(
+                #[test]
+                fn $name() {
+                    if is_aarch64_feature_detected_!($feature_name) {
+                        test_complex_packed_kernel::<$kernel_ty, _, TReal>(stringify!($name));
+                    } else {
+                        #[cfg(feature = "std")]
+                        println!("Skipping, host does not have feature: {:?}", $feature_name);
+                    }
+                }
+                )*
+            }
+        }
+
+        test_arch_kernels! {
+            "neon", neon, KernelNeon
+        }
     }
 
     #[cfg(any(target_arch="x86", target_arch="x86_64"))]


### PR DESCRIPTION
**Complex (cgemm, zgemm):**

Use a different pack layout for complex micorkernels which puts real and
imag parts in separate rows. This enables much better autovectorization for
the fallback kernels.

Also enable an Avx2 + Fma autovectorized kernel.

Performance improvements (all kernels autovectorized for cgemm, zgemm
at this time)

- AArch64 NEON (apple m1): cgemm: +60%, zgemm +10% 
- Fma + Avx (Intel Tiger lake) cgemm: +143%
- Fma + Avx2 (Intel Tiger lake) cgemm: +395% (new),  zgemm: +77% (new)

**Float (sgemm, dgemm):**

When the kernels can now select their own packing functions, instantiate
an avx2 version of the general packing function for sgemm and dgemm.

Packing performance matters most for small matrix multiplications, for
bigger sizes it is a vanishingly small part of runtime.

- Avx2 (Intel Tiger Lake): sgemm improves 6-16%, dgemm improves 0-8%
  depending on input layouts. Tested on M, K, N = 32, i.e a small matrix.