### PR TITLE
request 8-byte buffer alignment on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,10 +124,7 @@ jobs:
           - rust: stable
             target: aarch64-unknown-linux-gnu
             features: constconf cgemm threading
-          - rust: 1.61.0
-            target: aarch64-unknown-linux-gnu
-            features: cgemm
-          - rust: 1.41.1  # MSRV
+          - rust: 1.65.0
             target: aarch64-unknown-linux-gnu
             features: cgemm
 

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -342,9 +342,10 @@ const MASK_BUF_SIZE: usize = KERNEL_MAX_SIZE + KERNEL_MAX_ALIGN - 1;
 
 // Pointers into buffer will be manually aligned anyway, due to
 // bugs we have seen on certain platforms (macos) that look like
-// we don't get more than 16-aligned allocations out of TLS
+// we don't get aligned allocations out of TLS - 16- and 8-byte
+// allocations have been seen, make the minimal align request we can.
 #[cfg_attr(not(target_os = "macos"), repr(align(32)))]
-#[cfg_attr(target_os = "macos", repr(align(16)))]
+#[cfg_attr(target_os = "macos", repr(align(8)))]
 struct MaskBuffer {
     buffer: [u8; MASK_BUF_SIZE],
 }


### PR DESCRIPTION
A user showed that in certain configurations, the TLS allocation can even be 8-byte aligned.

Fixes rust-ndarray/ndarray#1327