### PR TITLE
Fix alignment in s390x and cross test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   MATMUL_NUM_THREADS: 4
+  RUST_BACKTRACE: full
 
 jobs:
   tests:
@@ -120,6 +121,9 @@ jobs:
       matrix:
         include:
           - rust: stable
+            target: s390x-unknown-linux-gnu
+            features: constconf cgemm threading
+          - rust: stable
             target: aarch64-unknown-linux-gnu
             features: constconf cgemm threading
           - rust: 1.65.0
@@ -146,7 +150,11 @@ jobs:
         run: cross test --target "${{ matrix.target }}" --features "${{ matrix.features }}"
         env:
           MMTEST_FAST_TEST: 1
-          RUSTFLAGS: -Copt-level=2
+      - name: Tests (Release)
+        run: cross test --release --target "${{ matrix.target }}" --features "${{ matrix.features }}"
+        env:
+          MMTEST_FAST_TEST: 1
+
 
   cargo-careful:
     runs-on: ubuntu-latest

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -344,7 +344,8 @@ const MASK_BUF_SIZE: usize = KERNEL_MAX_SIZE + KERNEL_MAX_ALIGN - 1;
 // bugs we have seen on certain platforms (macos) that look like
 // we don't get aligned allocations out of TLS - 16- and 8-byte
 // allocations have been seen, make the minimal align request we can.
-#[cfg_attr(not(target_os = "macos"), repr(align(32)))]
+// Align(32) would not work with TLS for s390x.
+#[cfg_attr(not(target_os = "macos"), repr(align(16)))]
 struct MaskBuffer {
     buffer: [u8; MASK_BUF_SIZE],
 }


### PR DESCRIPTION
Requested 32-alignment for s390x but thread local storage does not
supply it. Lower requested align to 16 in general to avoid having this
problem pop up on other platforms too.

Dynamic code downstream updates alignment to kernel's requested alignment, which can be larger than the base (static) alignment request.