### PR TITLE
Exclude alignment for MaskBuffer for i686-win7-windows-msvc

### DIFF
--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -345,7 +345,19 @@ const MASK_BUF_SIZE: usize = KERNEL_MAX_SIZE + KERNEL_MAX_ALIGN - 1;
 // we don't get aligned allocations out of TLS - 16- and 8-byte
 // allocations have been seen, make the minimal align request we can.
 // Align(32) would not work with TLS for s390x.
-#[cfg_attr(not(target_os = "macos"), repr(align(16)))]
+#[cfg_attr(
+    not(any(
+        target_os = "macos",
+        // Target i686-win7-windows-msvc <https://github.com/rust-lang/rust/issues/138903>
+        all(
+            target_arch = "x86",
+            target_vendor = "win7",
+            target_os = "windows",
+            target_env = "msvc"
+        )
+    )),
+    repr(align(16))
+)]
 struct MaskBuffer {
     buffer: [u8; MASK_BUF_SIZE],
 }


### PR DESCRIPTION
Windows 7 does not respect 16 byte alignment for thread locals on i686
builds. Rust 1.79 changed i686 windows builds to use native thread local
support. As a result, using `matrixmultiply` on i686 win7 builds leads
to a UB check panic nounwind when run on Windows 7. See
<https://github.com/rust-lang/rust/issues/138903> for more info.

This change adds `i686-win7-windows-msvc` as an excluded target for the
alignment attribute on `MaskBuffer`.

Not sure how you feel about adding this exclusion in `matrixmultiply` as its
very much for a tier 3 target that you can't test in CI that its useful. But
figured I'd raise it, as it would affect users using that target on any recent
toolchain version. And fwiw, i did test that this does in fact have the desire
for compilations targeting i686-win7
