### PR TITLE
Fix typo in architecture-specific parameters comment

### DIFF
--- a/src/archparam.rs
+++ b/src/archparam.rs
@@ -5,7 +5,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-//! architechture specific parameters
+//! architecture specific parameters
 //!
 //! NC: Columns in C, B that we handle at a time. (5th loop)
 //! KC: Rows of Bj at a time (4th loop)

--- a/src/archparam_defaults.rs
+++ b/src/archparam_defaults.rs
@@ -5,7 +5,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-//! architechture specific parameters
+//! architecture specific parameters
 
 /// Columns in C, B that we handle at a time. (5th loop)
 ///


### PR DESCRIPTION


**Description:**  
Corrected a typo in the documentation comments for architecture-specific parameters in both `archparam.rs` and `archparam_defaults.rs`. This improves code clarity and consistency.