### PR TITLE
Update itertools dev-dependency from 0.8 to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ num_cpus = { version = "1.13", optional = true }
 
 [dev-dependencies]
 bencher = "0.1.2"
-itertools = "0.8"
+itertools = "0.14"
 
 [features]
 default = ["std"]

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -6,9 +6,9 @@ extern crate matrixmultiply;
 
 use std::cell::Cell;
 use std::fmt::Debug;
+use std::iter::zip;
 use std::time::Instant;
 
-use itertools::zip;
 use itertools::Itertools;
 
 include!("../testdefs/testdefs.rs");


### PR DESCRIPTION
No code changes were *required*, but this PR also replaces the deprecated `itertools::zip` with `std::iter::zip`, available since Rust 1.59.