### PR TITLE
Exclude development scripts from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ Supports multithreading."""
 keywords = ["matrix", "sgemm", "dgemm"]
 categories = ["science"]
 
-exclude = ["docs/*"]
+include = ["README.rst", "build.rs", "LICENSE-MIT", "LICENSE-APACHE", "src/**/*.rs", "Cargo.toml"]
 
 build = "build.rs"
 


### PR DESCRIPTION
During a dependency review we noticed that the matrixmultiply crate includes various development scripts. These development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from being included in the published packages to make sure that everything that's included is an conscious choice.