### PR TITLE
upgrade itertools to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ num_cpus = { version = "1.13", optional = true }
 
 [dev-dependencies]
 bencher = "0.1.2"
-itertools = "0.8"
+itertools = "0.14"
 
 [features]
 default = ["std"]

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -7,8 +7,8 @@ extern crate matrixmultiply;
 use std::cell::Cell;
 use std::fmt::Debug;
 use std::time::Instant;
+use std::iter::zip;
 
-use itertools::zip;
 use itertools::Itertools;
 
 include!("../testdefs/testdefs.rs");


### PR DESCRIPTION
based on: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/matrixmultiply/debian/patches/relax-itertools.diff?ref_type=heads