### PR TITLE
Add AVX-512 kernel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,12 +214,18 @@ jobs:
   # run the test suite under Intel SDE to ensure AVX-512 kernels are available
   avx512_test:
     runs-on: ubuntu-latest
-    name: avx512_test/sde
+    strategy:
+      matrix:
+        include:
+          - rust: stable
+            target: x86_64-unknown-linux-gnu
+    name: avx512_test/${{ matrix.target }}/${{ matrix.rust }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
       - name: Set up Intel SDE
         # Sets SDE_PATH to the directory containing the SDE binaries
         uses: petarpetrovt/setup-sde@v5.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,3 +211,25 @@ jobs:
       - name: Miri
         run: ci/miri.sh --features cgemm
 
+  # run the test suite under Intel SDE to ensure AVX-512 kernels are available
+  avx512_test:
+    runs-on: ubuntu-latest
+    name: avx512_test/sde
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - name: Set up Intel SDE
+        # Sets SDE_PATH to the directory containing the SDE binaries
+        uses: petarpetrovt/setup-sde@v2.4
+      - name: Tests under SDE (force + ensure avx512f)
+        run: |
+          export PATH="$SDE_PATH:$PATH"
+          cargo test -v --tests --lib --release --no-fail-fast
+        env:
+          # Emulate a CPU with avx512f
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "sde64 -spr --"
+          MMTEST_FEATURE: avx512f
+          MMTEST_ENSUREFEATURE: 1
+          MMTEST_FAST_TEST: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
           toolchain: stable
       - name: Set up Intel SDE
         # Sets SDE_PATH to the directory containing the SDE binaries
-        uses: petarpetrovt/setup-sde@v2.4
+        uses: petarpetrovt/setup-sde@v5.0
       - name: Tests under SDE (force + ensure avx512f)
         run: |
           export PATH="$SDE_PATH:$PATH"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Tests under SDE (force + ensure avx512f)
         run: |
           export PATH="$SDE_PATH:$PATH"
-          cargo test -v --tests --lib --release --no-fail-fast
+          cargo test -v --tests --lib --release --no-fail-fast --features cgemm
         env:
           # Emulate a CPU with avx512f
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "sde64 -spr --"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/bluss/matrixmultiply/"
 documentation = "https://docs.rs/matrixmultiply/"
 
 description = """
-General matrix multiplication for f32 and f64 matrices. Operates on matrices with general layout (they can use arbitrary row and column stride). Detects and uses AVX or SSE2 on x86 platforms transparently for higher performance. Uses a microkernel strategy, so that the implementation is easy to parallelize and optimize.
+General matrix multiplication for f32 and f64 matrices. Operates on matrices with general layout (they can use arbitrary row and column stride). Detects and uses AVX-512, AVX or SSE2 on x86 platforms transparently for higher performance. Uses a microkernel strategy, so that the implementation is easy to parallelize and optimize.
 
 Supports multithreading."""
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,13 +43,14 @@ bencher = "0.1.2"
 itertools = "0.8"
 
 [features]
-default = ["std"]
+default = ["std", "avx512"]
 
 # support for complex f32, complex f64
 cgemm = []
 
 threading = ["thread-tree", "std", "once_cell", "num_cpus"]
 std = []
+avx512 = []
 
 # support for compile-time configuration
 constconf = []

--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,7 @@ Recent Changes
 - Unreleased
 
   - Add AVX-512 microkernels for sgemm (16×16) and dgemm (8×8)
+  - Add AVX-512 microkernels for cgemm (8×4) and zgemm (4×4)
 
 - 0.3.10
 

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,10 @@ __ https://bluss.github.io/rust/2016/03/28/a-gemmed-rabbit-hole/
 Recent Changes
 --------------
 
+- Unreleased
+
+  - Add AVX-512 microkernels for sgemm (16×16) and dgemm (8×8)
+
 - 0.3.10
 
   - sgemm: Reduce unnecessary AVX register permutations by `@SongXiaoXi <https://github.com/SongXiaoXi>`_ `#88 <https://github.com/bluss/matrixmultiply/pull/88>`_

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,14 +1,23 @@
 extern crate matrixmultiply;
 pub use matrixmultiply::dgemm;
 pub use matrixmultiply::sgemm;
+#[cfg(feature = "cgemm")]
+pub use matrixmultiply::{cgemm, zgemm, CGemmOption};
 
 #[macro_use]
 extern crate bencher;
 
 // Compute GFlop/s
-// by flop / s = 2 M N K / time
+// by flop / s = 2 M N K / time   (8 M N K for the complex kernels)
+// To benchmark a specific kernel, pin it at compile time with MMTEST_FEATURE
+// E.g. `MMTEST_FEATURE=avx512f cargo bench --features cgemm`
+// Use `MMTEST_FEATURE=fma` for a 256-bit (AVX2-class) baseline (do not use `MMTEST_FEATURE=avx2`)
 
+#[cfg(not(feature = "cgemm"))]
 benchmark_main!(mat_mul_f32, mat_mul_f64, layout_f32_032, layout_f64_032);
+#[cfg(feature = "cgemm")]
+benchmark_main!(mat_mul_f32, mat_mul_f64, layout_f32_032, layout_f64_032,
+                mat_mul_c32, mat_mul_c64);
 
 macro_rules! mat_mul {
     ($modname:ident, $gemm:ident, $(($name:ident, $m:expr, $n:expr, $k:expr))+) => {
@@ -75,6 +84,71 @@ mat_mul! {mat_mul_f64, dgemm,
     (mix32x2, 32, 2, 32)
     (mix97, 97, 97, 125)
     (mix128x10000x128, 128, 10000, 128)
+    */
+}
+
+// Complex size-sweep, sibling of `mat_mul!`
+#[cfg(feature = "cgemm")]
+macro_rules! cmat_mul {
+    ($modname:ident, $gemm:ident, $real:ty, $(($name:ident, $m:expr, $n:expr, $k:expr))+) => {
+        mod $modname {
+            use bencher::Bencher;
+            use crate::{$gemm, CGemmOption};
+            $(
+            pub fn $name(bench: &mut Bencher)
+            {
+                let a = vec![[0. as $real; 2]; $m * $n];
+                let b = vec![[0. as $real; 2]; $n * $k];
+                let mut c = vec![[0. as $real; 2]; $m * $k];
+                bench.iter(|| {
+                    unsafe {
+                        $gemm(
+                            CGemmOption::Standard, CGemmOption::Standard,
+                            $m, $n, $k,
+                            [1. as $real, 0. as $real],
+                            a.as_ptr(), $n, 1,
+                            b.as_ptr(), $k, 1,
+                            [0. as $real, 0. as $real],
+                            c.as_mut_ptr(), $k, 1,
+                            )
+                    }
+                });
+            }
+            )+
+        }
+        benchmark_group!{ $modname, $($modname::$name),+ }
+    };
+}
+
+#[cfg(feature = "cgemm")]
+cmat_mul! {mat_mul_c32, cgemm, f32,
+    (m004, 4, 4, 4)
+    (m006, 6, 6, 6)
+    (m008, 8, 8, 8)
+    (m012, 12, 12, 12)
+    (m016, 16, 16, 16)
+    (m032, 32, 32, 32)
+    (m064, 64, 64, 64)
+    (m127, 127, 127, 127)
+    /*
+    (m256, 256, 256, 256)
+    (m512, 512, 512, 512)
+    */
+}
+
+#[cfg(feature = "cgemm")]
+cmat_mul! {mat_mul_c64, zgemm, f64,
+    (m004, 4, 4, 4)
+    (m006, 6, 6, 6)
+    (m008, 8, 8, 8)
+    (m012, 12, 12, 12)
+    (m016, 16, 16, 16)
+    (m032, 32, 32, 32)
+    (m064, 64, 64, 64)
+    (m127, 127, 127, 127)
+    /*
+    (m256, 256, 256, 256)
+    (m512, 512, 512, 512)
     */
 }
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,23 +1,14 @@
 extern crate matrixmultiply;
 pub use matrixmultiply::dgemm;
 pub use matrixmultiply::sgemm;
-#[cfg(feature = "cgemm")]
-pub use matrixmultiply::{cgemm, zgemm, CGemmOption};
 
 #[macro_use]
 extern crate bencher;
 
 // Compute GFlop/s
-// by flop / s = 2 M N K / time   (8 M N K for the complex kernels)
-// To benchmark a specific kernel, pin it at compile time with MMTEST_FEATURE
-// E.g. `MMTEST_FEATURE=avx512f cargo bench --features cgemm`
-// Use `MMTEST_FEATURE=fma` for a 256-bit (AVX2-class) baseline (do not use `MMTEST_FEATURE=avx2`)
+// by flop / s = 2 M N K / time
 
-#[cfg(not(feature = "cgemm"))]
 benchmark_main!(mat_mul_f32, mat_mul_f64, layout_f32_032, layout_f64_032);
-#[cfg(feature = "cgemm")]
-benchmark_main!(mat_mul_f32, mat_mul_f64, layout_f32_032, layout_f64_032,
-                mat_mul_c32, mat_mul_c64);
 
 macro_rules! mat_mul {
     ($modname:ident, $gemm:ident, $(($name:ident, $m:expr, $n:expr, $k:expr))+) => {
@@ -84,71 +75,6 @@ mat_mul! {mat_mul_f64, dgemm,
     (mix32x2, 32, 2, 32)
     (mix97, 97, 97, 125)
     (mix128x10000x128, 128, 10000, 128)
-    */
-}
-
-// Complex size-sweep, sibling of `mat_mul!`
-#[cfg(feature = "cgemm")]
-macro_rules! cmat_mul {
-    ($modname:ident, $gemm:ident, $real:ty, $(($name:ident, $m:expr, $n:expr, $k:expr))+) => {
-        mod $modname {
-            use bencher::Bencher;
-            use crate::{$gemm, CGemmOption};
-            $(
-            pub fn $name(bench: &mut Bencher)
-            {
-                let a = vec![[0. as $real; 2]; $m * $n];
-                let b = vec![[0. as $real; 2]; $n * $k];
-                let mut c = vec![[0. as $real; 2]; $m * $k];
-                bench.iter(|| {
-                    unsafe {
-                        $gemm(
-                            CGemmOption::Standard, CGemmOption::Standard,
-                            $m, $n, $k,
-                            [1. as $real, 0. as $real],
-                            a.as_ptr(), $n, 1,
-                            b.as_ptr(), $k, 1,
-                            [0. as $real, 0. as $real],
-                            c.as_mut_ptr(), $k, 1,
-                            )
-                    }
-                });
-            }
-            )+
-        }
-        benchmark_group!{ $modname, $($modname::$name),+ }
-    };
-}
-
-#[cfg(feature = "cgemm")]
-cmat_mul! {mat_mul_c32, cgemm, f32,
-    (m004, 4, 4, 4)
-    (m006, 6, 6, 6)
-    (m008, 8, 8, 8)
-    (m012, 12, 12, 12)
-    (m016, 16, 16, 16)
-    (m032, 32, 32, 32)
-    (m064, 64, 64, 64)
-    (m127, 127, 127, 127)
-    /*
-    (m256, 256, 256, 256)
-    (m512, 512, 512, 512)
-    */
-}
-
-#[cfg(feature = "cgemm")]
-cmat_mul! {mat_mul_c64, zgemm, f64,
-    (m004, 4, 4, 4)
-    (m006, 6, 6, 6)
-    (m008, 8, 8, 8)
-    (m012, 12, 12, 12)
-    (m016, 16, 16, 16)
-    (m032, 32, 32, 32)
-    (m064, 64, 64, 64)
-    (m127, 127, 127, 127)
-    /*
-    (m256, 256, 256, 256)
-    (m512, 512, 512, 512)
     */
 }
 

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,30 @@
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    if std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or(String::new()) == "aarch64" {
-        match autocfg::AutoCfg::new() {
-            // From 1.61 aarch64 intrinsics and #[target_feature]
-            Ok(ac) => if ac.probe_rustc_version(1, 61) {
-                println!("cargo:rustc-cfg=has_aarch64_simd");
-            }
-            Err(err) => println!("cargo:warning={}", err),
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or(String::new());
+
+    let ac = match autocfg::AutoCfg::new() {
+        Ok(ac) => ac,
+        Err(err) => {
+            println!("cargo:warning={}", err);
+            return;
+        }
+    };
+
+    // Avoid `unexpected_cfgs` lint from 1.80+ toolchains
+    if ac.probe_rustc_version(1, 80) {
+        println!("cargo::rustc-check-cfg=cfg(has_avx512)");
+    }
+
+    if target_arch == "aarch64" {
+        // From 1.61 aarch64 intrinsics and #[target_feature]
+        if ac.probe_rustc_version(1, 61) {
+            println!("cargo:rustc-cfg=has_aarch64_simd");
+        }
+    }
+    if target_arch == "x86" || target_arch == "x86_64" {
+        // From 1.89 AVX-512 intrinsics ("avx512f")
+        if ac.probe_rustc_version(1, 89) {
+            println!("cargo:rustc-cfg=has_avx512");
         }
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,9 @@ fn main() {
     }
     if target_arch == "x86" || target_arch == "x86_64" {
         // From 1.89 AVX-512 intrinsics ("avx512f")
-        if ac.probe_rustc_version(1, 89) {
+        if ac.probe_rustc_version(1, 89)
+            && std::env::var_os("CARGO_FEATURE_AVX512").is_some()
+        {
             println!("cargo:rustc-cfg=has_avx512");
         }
     }

--- a/src/cgemm_kernel.rs
+++ b/src/cgemm_kernel.rs
@@ -371,14 +371,8 @@ mod tests {
         }
 
         #[cfg(has_avx512)]
-        #[test]
-        fn avx512f() {
-            if is_x86_feature_detected_!("avx512f") {
-                test_complex_packed_kernel::<KernelAvx512, _, TReal>("avx512f");
-            } else {
-                #[cfg(feature = "std")]
-                println!("Skipping, host does not have feature: {:?}", "avx512f");
-            }
+        test_arch_kernels_x86! {
+            "avx512f", avx512f, KernelAvx512
         }
     }
 }

--- a/src/cgemm_kernel.rs
+++ b/src/cgemm_kernel.rs
@@ -9,10 +9,14 @@
 use crate::kernel::GemmKernel;
 use crate::kernel::GemmSelect;
 use crate::kernel::{U2, U4, c32, Element, c32_mul as mul};
+#[cfg(has_avx512)]
+use crate::kernel::U8;
 use crate::archparam;
 use crate::cgemm_common::pack_complex;
 use crate::packing::PackSlice;
 
+#[cfg(has_avx512)]
+struct KernelAvx512;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 struct KernelAvx2;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
@@ -37,6 +41,12 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
     // dispatch to specific compiled versions
     #[cfg(any(target_arch="x86", target_arch="x86_64"))]
     {
+        #[cfg(has_avx512)]
+        {
+            if is_x86_feature_detected_!("avx512f") {
+                return selector.select(KernelAvx512);
+            }
+        }
         if is_x86_feature_detected_!("fma") {
             if is_x86_feature_detected_!("avx2") {
                 return selector.select(KernelAvx2);
@@ -52,6 +62,40 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
         }
     }
     return selector.select(KernelFallback);
+}
+
+#[cfg(has_avx512)]
+impl GemmKernel for KernelAvx512 {
+    type Elem = T;
+
+    type MRTy = U8;
+    type NRTy = U4;
+
+    #[inline(always)]
+    fn align_to() -> usize { 32 }
+
+    #[inline(always)]
+    fn always_masked() -> bool { KernelFallback::always_masked() }
+
+    #[inline(always)]
+    fn nc() -> usize { archparam::C_NC }
+    #[inline(always)]
+    fn kc() -> usize { archparam::C_KC }
+    #[inline(always)]
+    fn mc() -> usize { archparam::C_MC }
+
+    pack_methods!{}
+
+    #[inline(always)]
+    unsafe fn kernel(
+        k: usize,
+        alpha: T,
+        a: *const T,
+        b: *const T,
+        beta: T,
+        c: *mut T, rsc: isize, csc: isize) {
+        kernel_target_avx512(k, alpha, a, b, beta, c, rsc, csc)
+    }
 }
 
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
@@ -190,6 +234,19 @@ impl GemmKernel for KernelFallback {
     }
 }
 
+// Kernel AVX-512
+#[cfg(has_avx512)]
+macro_rules! loop_m { ($i:ident, $e:expr) => { loop8!($i, $e) }; }
+#[cfg(has_avx512)]
+macro_rules! loop_n { ($j:ident, $e:expr) => { loop4!($j, $e) }; }
+
+#[cfg(has_avx512)]
+kernel_fallback_impl_complex! {
+    // instantiate separately
+    [inline target_feature(enable="avx512f")] [fma_yes]
+    kernel_target_avx512, T, TReal, KernelAvx512::MR, KernelAvx512::NR, 4
+}
+
 // Kernel AVX2
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 macro_rules! loop_m { ($i:ident, $e:expr) => { loop4!($i, $e) }; }
@@ -311,6 +368,17 @@ mod tests {
         test_arch_kernels_x86! {
             "fma", fma, KernelFma,
             "avx2", avx2, KernelAvx2
+        }
+
+        #[cfg(has_avx512)]
+        #[test]
+        fn avx512f() {
+            if is_x86_feature_detected_!("avx512f") {
+                test_complex_packed_kernel::<KernelAvx512, _, TReal>("avx512f");
+            } else {
+                #[cfg(feature = "std")]
+                println!("Skipping, host does not have feature: {:?}", "avx512f");
+            }
         }
     }
 }

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -264,7 +264,7 @@ impl GemmKernel for KernelAvx512 {
     fn mc() -> usize { archparam::D_MC }
 
     #[inline]
-    unsafe fn pack_mr(kc: usize, mc: usize, pack: &mut [Self::Elem],
+    unsafe fn pack_mr(kc: usize, mc: usize, pack: PackSlice<Self::Elem>,
                       a: *const Self::Elem, rsa: isize, csa: isize)
     {
         // safety: avx512f is enabled
@@ -272,7 +272,7 @@ impl GemmKernel for KernelAvx512 {
     }
 
     #[inline]
-    unsafe fn pack_nr(kc: usize, mc: usize, pack: &mut [Self::Elem],
+    unsafe fn pack_nr(kc: usize, mc: usize, pack: PackSlice<Self::Elem>,
                       a: *const Self::Elem, rsa: isize, csa: isize)
     {
         // safety: avx512f is enabled

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -263,6 +263,22 @@ impl GemmKernel for KernelAvx512 {
     #[inline(always)]
     fn mc() -> usize { archparam::D_MC }
 
+    #[inline]
+    unsafe fn pack_mr(kc: usize, mc: usize, pack: &mut [Self::Elem],
+                      a: *const Self::Elem, rsa: isize, csa: isize)
+    {
+        // safety: any CPU with avx512f also has avx2
+        crate::packing::pack_avx2::<Self::MRTy, T>(kc, mc, pack, a, rsa, csa)
+    }
+
+    #[inline]
+    unsafe fn pack_nr(kc: usize, mc: usize, pack: &mut [Self::Elem],
+                      a: *const Self::Elem, rsa: isize, csa: isize)
+    {
+        // safety: any CPU with avx512f also has avx2
+        crate::packing::pack_avx2::<Self::NRTy, T>(kc, mc, pack, a, rsa, csa)
+    }
+
     #[inline(always)]
     unsafe fn kernel(
         k: usize,
@@ -924,10 +940,6 @@ unsafe fn kernel_x86_avx<MA>(k: usize, alpha: T, a: *const T, b: *const T,
 }
 
 // no inline for unmasked kernels
-// 8x8 dgemm microkernel using a broadcast (rank-1 update) scheme (the f64
-// analogue of the sgemm AVX-512 kernel): each accumulator holds one 8-wide row
-// of C; per k step we load one row of packed B and FMA it against each
-// broadcast element of packed A.
 #[cfg(has_avx512)]
 #[target_feature(enable="avx512f")]
 unsafe fn kernel_target_avx512(k: usize, alpha: T, a: *const T, b: *const T,
@@ -955,37 +967,40 @@ unsafe fn kernel_target_avx512(k: usize, alpha: T, a: *const T, b: *const T,
         }
     });
 
-    // ab = alpha * (A B)
-    let alphav = _mm512_set1_pd(alpha);
-    loop8!(i, ab[i] = _mm512_mul_pd(alphav, ab[i]));
-
     macro_rules! c {
         ($i:expr, $j:expr) => (c.offset(rsc * $i as isize + csc * $j as isize));
     }
 
-    // ab = ab + beta * C
+    // C <- alpha (A B) + beta C, in a single epilogue pass
+    // Fold alpha into the final FMA
+    // When beta == 0 the kernel must not read C
+    let alphav = _mm512_set1_pd(alpha);
     if beta != 0. {
         let betav = _mm512_set1_pd(beta);
         if csc == 1 {
-            loop8!(i, ab[i] = _mm512_fmadd_pd(_mm512_loadu_pd(c![i, 0]), betav, ab[i]));
+            loop8!(i, {
+                let cv = _mm512_mul_pd(_mm512_loadu_pd(c![i, 0]), betav);
+                _mm512_storeu_pd(c![i, 0], _mm512_fmadd_pd(alphav, ab[i], cv));
+            });
         } else {
             loop8!(i, {
                 let mut tmp = [0.; NR];
                 for j in 0..NR { tmp[j] = *c![i, j]; }
-                ab[i] = _mm512_fmadd_pd(_mm512_loadu_pd(tmp.as_ptr()), betav, ab[i]);
+                let cv = _mm512_mul_pd(_mm512_loadu_pd(tmp.as_ptr()), betav);
+                _mm512_storeu_pd(tmp.as_mut_ptr(), _mm512_fmadd_pd(alphav, ab[i], cv));
+                for j in 0..NR { *c![i, j] = tmp[j]; }
             });
         }
-    }
-
-    // Store C back to memory
-    if csc == 1 {
-        loop8!(i, _mm512_storeu_pd(c![i, 0], ab[i]));
     } else {
-        loop8!(i, {
-            let mut tmp = [0.; NR];
-            _mm512_storeu_pd(tmp.as_mut_ptr(), ab[i]);
-            for j in 0..NR { *c![i, j] = tmp[j]; }
-        });
+        if csc == 1 {
+            loop8!(i, _mm512_storeu_pd(c![i, 0], _mm512_mul_pd(alphav, ab[i])));
+        } else {
+            loop8!(i, {
+                let mut tmp = [0.; NR];
+                _mm512_storeu_pd(tmp.as_mut_ptr(), _mm512_mul_pd(alphav, ab[i]));
+                for j in 0..NR { *c![i, j] = tmp[j]; }
+            });
+        }
     }
 }
 

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -267,16 +267,16 @@ impl GemmKernel for KernelAvx512 {
     unsafe fn pack_mr(kc: usize, mc: usize, pack: &mut [Self::Elem],
                       a: *const Self::Elem, rsa: isize, csa: isize)
     {
-        // safety: any CPU with avx512f also has avx2
-        crate::packing::pack_avx2::<Self::MRTy, T>(kc, mc, pack, a, rsa, csa)
+        // safety: avx512f is enabled
+        crate::packing::pack_avx512::<Self::MRTy, T>(kc, mc, pack, a, rsa, csa)
     }
 
     #[inline]
     unsafe fn pack_nr(kc: usize, mc: usize, pack: &mut [Self::Elem],
                       a: *const Self::Elem, rsa: isize, csa: isize)
     {
-        // safety: any CPU with avx512f also has avx2
-        crate::packing::pack_avx2::<Self::NRTy, T>(kc, mc, pack, a, rsa, csa)
+        // safety: avx512f is enabled
+        crate::packing::pack_avx512::<Self::NRTy, T>(kc, mc, pack, a, rsa, csa)
     }
 
     #[inline(always)]

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -30,6 +30,8 @@ struct KernelFmaAvx2;
 struct KernelFma;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 struct KernelSse2;
+#[cfg(has_avx512)]
+struct KernelAvx512;
 
 #[cfg(target_arch="aarch64")]
 #[cfg(has_aarch64_simd)]
@@ -49,6 +51,12 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
     // dispatch to specific compiled versions
     #[cfg(any(target_arch="x86", target_arch="x86_64"))]
     {
+        #[cfg(has_avx512)]
+        {
+            if is_x86_feature_detected_!("avx512f") {
+                return selector.select(KernelAvx512);
+            }
+        }
         if is_x86_feature_detected_!("fma") {
             if is_x86_feature_detected_!("avx2") {
                 return selector.select(KernelFmaAvx2);
@@ -232,6 +240,38 @@ impl GemmKernel for KernelSse2 {
         csc: isize)
     {
         kernel_target_sse2(k, alpha, a, b, beta, c, rsc, csc)
+    }
+}
+
+#[cfg(has_avx512)]
+impl GemmKernel for KernelAvx512 {
+    type Elem = T;
+
+    type MRTy = U8;
+    type NRTy = U8;
+
+    #[inline(always)]
+    fn align_to() -> usize { 32 }
+
+    #[inline(always)]
+    fn always_masked() -> bool { false }
+
+    #[inline(always)]
+    fn nc() -> usize { archparam::D_NC }
+    #[inline(always)]
+    fn kc() -> usize { archparam::D_KC }
+    #[inline(always)]
+    fn mc() -> usize { archparam::D_MC }
+
+    #[inline(always)]
+    unsafe fn kernel(
+        k: usize,
+        alpha: T,
+        a: *const T,
+        b: *const T,
+        beta: T,
+        c: *mut T, rsc: isize, csc: isize) {
+        kernel_target_avx512(k, alpha, a, b, beta, c, rsc, csc)
     }
 }
 
@@ -883,6 +923,72 @@ unsafe fn kernel_x86_avx<MA>(k: usize, alpha: T, a: *const T, b: *const T,
     }
 }
 
+// no inline for unmasked kernels
+// 8x8 dgemm microkernel using a broadcast (rank-1 update) scheme (the f64
+// analogue of the sgemm AVX-512 kernel): each accumulator holds one 8-wide row
+// of C; per k step we load one row of packed B and FMA it against each
+// broadcast element of packed A.
+#[cfg(has_avx512)]
+#[target_feature(enable="avx512f")]
+unsafe fn kernel_target_avx512(k: usize, alpha: T, a: *const T, b: *const T,
+                               beta: T, c: *mut T, rsc: isize, csc: isize)
+{
+    const MR: usize = KernelAvx512::MR;
+    const NR: usize = KernelAvx512::NR;
+    debug_assert_ne!(k, 0);
+
+    let mut ab = [_mm512_setzero_pd(); MR];
+
+    // Compute C in whichever orientation makes the output columns contiguous.
+    let prefer_row_major_c = rsc != 1;
+    let (mut a, mut b) = if prefer_row_major_c { (a, b) } else { (b, a) };
+    let (rsc, csc) = if prefer_row_major_c { (rsc, csc) } else { (csc, rsc) };
+
+    // Compute A B. Load one 8-wide row of B, FMA against each broadcast A elem.
+    let mut bv = _mm512_loadu_pd(b);
+    unroll_by_with_last!(4 => k, is_last, {
+        loop8!(i, ab[i] = _mm512_fmadd_pd(_mm512_set1_pd(*a.add(i)), bv, ab[i]));
+        if !is_last {
+            a = a.add(MR);
+            b = b.add(NR);
+            bv = _mm512_loadu_pd(b);
+        }
+    });
+
+    // ab = alpha * (A B)
+    let alphav = _mm512_set1_pd(alpha);
+    loop8!(i, ab[i] = _mm512_mul_pd(alphav, ab[i]));
+
+    macro_rules! c {
+        ($i:expr, $j:expr) => (c.offset(rsc * $i as isize + csc * $j as isize));
+    }
+
+    // ab = ab + beta * C
+    if beta != 0. {
+        let betav = _mm512_set1_pd(beta);
+        if csc == 1 {
+            loop8!(i, ab[i] = _mm512_fmadd_pd(_mm512_loadu_pd(c![i, 0]), betav, ab[i]));
+        } else {
+            loop8!(i, {
+                let mut tmp = [0.; NR];
+                for j in 0..NR { tmp[j] = *c![i, j]; }
+                ab[i] = _mm512_fmadd_pd(_mm512_loadu_pd(tmp.as_ptr()), betav, ab[i]);
+            });
+        }
+    }
+
+    // Store C back to memory
+    if csc == 1 {
+        loop8!(i, _mm512_storeu_pd(c![i, 0], ab[i]));
+    } else {
+        loop8!(i, {
+            let mut tmp = [0.; NR];
+            _mm512_storeu_pd(tmp.as_mut_ptr(), ab[i]);
+            for j in 0..NR { *c![i, j] = tmp[j]; }
+        });
+    }
+}
+
 #[cfg(target_arch="aarch64")]
 #[cfg(has_aarch64_simd)]
 #[target_feature(enable="neon")]
@@ -1123,6 +1229,17 @@ mod tests {
             "fma", fma, KernelFma,
             "avx", avx, KernelAvx,
             "sse2", sse2, KernelSse2
+        }
+
+        #[cfg(has_avx512)]
+        #[test]
+        fn avx512f() {
+            if is_x86_feature_detected_!("avx512f") {
+                test_a_kernel::<KernelAvx512, _>("avx512f");
+            } else {
+                #[cfg(feature = "std")]
+                println!("Skipping, host does not have feature: {:?}", "avx512f");
+            }
         }
     }
 }

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -1247,14 +1247,8 @@ mod tests {
         }
 
         #[cfg(has_avx512)]
-        #[test]
-        fn avx512f() {
-            if is_x86_feature_detected_!("avx512f") {
-                test_a_kernel::<KernelAvx512, _>("avx512f");
-            } else {
-                #[cfg(feature = "std")]
-                println!("Skipping, host does not have feature: {:?}", "avx512f");
-            }
+        test_arch_kernels_x86! {
+            "avx512f", avx512f, KernelAvx512
         }
     }
 }

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -251,7 +251,7 @@ impl GemmKernel for KernelAvx512 {
     type NRTy = U8;
 
     #[inline(always)]
-    fn align_to() -> usize { 32 }
+    fn align_to() -> usize { 64 }
 
     #[inline(always)]
     fn always_masked() -> bool { false }
@@ -956,14 +956,14 @@ unsafe fn kernel_target_avx512(k: usize, alpha: T, a: *const T, b: *const T,
     let (mut a, mut b) = if prefer_row_major_c { (a, b) } else { (b, a) };
     let (rsc, csc) = if prefer_row_major_c { (rsc, csc) } else { (csc, rsc) };
 
-    // Compute A B. Load one 8-wide row of B, FMA against each broadcast A elem.
-    let mut bv = _mm512_loadu_pd(b);
+    // Compute A B. The packed buffers are 64-byte aligned
+    let mut bv = _mm512_load_pd(b);
     unroll_by_with_last!(4 => k, is_last, {
         loop8!(i, ab[i] = _mm512_fmadd_pd(_mm512_set1_pd(*a.add(i)), bv, ab[i]));
         if !is_last {
             a = a.add(MR);
             b = b.add(NR);
-            bv = _mm512_loadu_pd(b);
+            bv = _mm512_load_pd(b);
         }
     });
 

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -350,7 +350,11 @@ unsafe fn gemm_loop<K>(
 const KERNEL_MAX_SIZE: usize = 8 * 8 * 4;
 #[cfg(has_avx512)]
 const KERNEL_MAX_SIZE: usize = 16 * 16 * 4;
+#[cfg(not(has_avx512))]
 const KERNEL_MAX_ALIGN: usize = 32;
+// The AVX-512 kernels load a full 64-byte ZMM register
+#[cfg(has_avx512)]
+const KERNEL_MAX_ALIGN: usize = 64;
 const MASK_BUF_SIZE: usize = KERNEL_MAX_SIZE + KERNEL_MAX_ALIGN - 1;
 
 // Pointers into buffer will be manually aligned anyway, due to

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -242,7 +242,6 @@ fn ensure_kernel_params<K>()
     let nr = K::NR;
     // These are current limitations,
     // can change if corresponding code in gemm_loop is updated.
-    // The bounds widen when AVX-512 is enabled (see KERNEL_MAX_* below).
     assert!(mr > 0 && mr <= KERNEL_MAX_MR);
     assert!(nr > 0 && nr <= KERNEL_MAX_NR);
     assert!(mr * nr * size_of::<K::Elem>() <= KERNEL_MAX_SIZE);

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -220,6 +220,15 @@ impl<T> GemmSelect<T> for GemmParameters<T> {
     }
 }
 
+#[cfg(not(has_avx512))]
+const KERNEL_MAX_MR: usize = 8;
+#[cfg(not(has_avx512))]
+const KERNEL_MAX_NR: usize = 8;
+// Widen MR and NR when AVX-512 is enabled
+#[cfg(has_avx512)]
+const KERNEL_MAX_MR: usize = 16;
+#[cfg(has_avx512)]
+const KERNEL_MAX_NR: usize = 16;
 
 /// Ensure that GemmKernel parameters are supported
 /// (alignment, microkernel size).
@@ -233,10 +242,11 @@ fn ensure_kernel_params<K>()
     let nr = K::NR;
     // These are current limitations,
     // can change if corresponding code in gemm_loop is updated.
-    assert!(mr > 0 && mr <= 8);
-    assert!(nr > 0 && nr <= 8);
-    assert!(mr * nr * size_of::<K::Elem>() <= 8 * 4 * 8);
-    assert!(K::align_to() <= 32);
+    // The bounds widen when AVX-512 is enabled (see KERNEL_MAX_* below).
+    assert!(mr > 0 && mr <= KERNEL_MAX_MR);
+    assert!(nr > 0 && nr <= KERNEL_MAX_NR);
+    assert!(mr * nr * size_of::<K::Elem>() <= KERNEL_MAX_SIZE);
+    assert!(K::align_to() <= KERNEL_MAX_ALIGN);
     // one row/col of the kernel is limiting the max align we can provide
     let max_align = size_of::<K::Elem>() * min(mr, nr);
     assert!(K::align_to() <= max_align);
@@ -337,7 +347,10 @@ unsafe fn gemm_loop<K>(
 }
 
 // set up buffer for masked (redirected output of) kernel
+#[cfg(not(has_avx512))]
 const KERNEL_MAX_SIZE: usize = 8 * 8 * 4;
+#[cfg(has_avx512)]
+const KERNEL_MAX_SIZE: usize = 16 * 16 * 4;
 const KERNEL_MAX_ALIGN: usize = 32;
 const MASK_BUF_SIZE: usize = KERNEL_MAX_SIZE + KERNEL_MAX_ALIGN - 1;
 
@@ -489,7 +502,7 @@ unsafe fn align_ptr<T>(mut align_to: usize, mut ptr: *mut T) -> *mut T {
 }
 
 /// Call the GEMM kernel with a "masked" output C.
-/// 
+///
 /// Simply redirect the MR by NR kernel output to the passed
 /// in `mask_buf`, and copy the non masked region to the real
 /// C.

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -199,11 +199,15 @@ pub(crate) trait ConstNum {
 pub(crate) struct U2;
 pub(crate) struct U4;
 pub(crate) struct U8;
+#[cfg(has_avx512)]
+pub(crate) struct U16;
 
 #[cfg(feature = "cgemm")]
 impl ConstNum for U2 { const VALUE: usize = 2; }
 impl ConstNum for U4 { const VALUE: usize = 4; }
 impl ConstNum for U8 { const VALUE: usize = 8; }
+#[cfg(has_avx512)]
+impl ConstNum for U16 { const VALUE: usize = 16; }
 
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 //!   - `fma`
 //!   - `avx`
 //!   - `sse2`
-//!   - `avx512` (Rust 1.89 or later)
+//!   - `avx512f`
 //!
 //! - *aarch64* features can be detected at runtime by default or compile time
 //!   (if enabled), and the following kernel variants are implemented:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,7 @@
 //!   - `fma`
 //!   - `avx`
 //!   - `sse2`
-//!   - `avx512` (the AVX-512 kernels require Rust 1.89 or later; on older
-//!     compilers the crate transparently falls back to the `fma`/`avx` kernels)
+//!   - `avx512` (Rust 1.89 or later)
 //!
 //! - *aarch64* features can be detected at runtime by default or compile time
 //!   (if enabled), and the following kernel variants are implemented:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@
 //!   - `fma`
 //!   - `avx`
 //!   - `sse2`
+//!   - `avx512` (the AVX-512 kernels require Rust 1.89 or later; on older
+//!     compilers the crate transparently falls back to the `fma`/`avx` kernels)
 //!
 //! - *aarch64* features can be detected at runtime by default or compile time
 //!   (if enabled), and the following kernel variants are implemented:
@@ -128,7 +130,8 @@
 //! considered upgrade policy, where updating the minimum Rust version is not a breaking
 //! change.
 //!
-//! Some features are enabled with later versions: from Rust 1.61 AArch64 NEON support.
+//! Some features are enabled with later versions: from Rust 1.61 AArch64 NEON
+//! support, and from Rust 1.89 x86/x86-64 AVX-512 support.
 
 #![doc(html_root_url = "https://docs.rs/matrixmultiply/0.3/")]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,19 @@
 //! [`target-feature`](https://doc.rust-lang.org/rustc/codegen-options/index.html#target-feature)
 //! option to `rustc`.)
 //!
+//! ### `avx512`
+//!
+//! `avx512` is enabled by default.
+//!
+//! It compiles the AVX-512 kernels, which are then used at runtime on CPUs
+//! that support the `avx512f` (maybe more avx512 subsets support in the future) target feature.
+//! It requires Rust 1.89 or later and has no effect on older compilers.
+//! To disable it, use this in your `Cargo.toml`:
+//!
+//! ```toml
+//! matrixmultiply = { version = "0.3", default-features = false, features = ["std"] }
+//! ```
+//!
 //! ### `threading`
 //!
 //! `threading` is an optional crate feature

--- a/src/loopmacros.rs
+++ b/src/loopmacros.rs
@@ -66,6 +66,38 @@ macro_rules! loop8 {
     }}
 }
 
+// AVX-512 sgemm microkernel (16 kernel rows)
+#[allow(unused)]
+#[cfg(debug_assertions)]
+macro_rules! loop16 {
+    ($i:ident, $e:expr) => {
+        for $i in 0..16 { $e }
+    }
+}
+
+#[allow(unused)]
+#[cfg(not(debug_assertions))]
+macro_rules! loop16 {
+    ($i:ident, $e:expr) => {{
+        let $i = 0; $e;
+        let $i = 1; $e;
+        let $i = 2; $e;
+        let $i = 3; $e;
+        let $i = 4; $e;
+        let $i = 5; $e;
+        let $i = 6; $e;
+        let $i = 7; $e;
+        let $i = 8; $e;
+        let $i = 9; $e;
+        let $i = 10; $e;
+        let $i = 11; $e;
+        let $i = 12; $e;
+        let $i = 13; $e;
+        let $i = 14; $e;
+        let $i = 15; $e;
+    }}
+}
+
 #[cfg(debug_assertions)]
 macro_rules! unroll_by {
     ($by:tt => $ntimes:expr, $e:expr) => {

--- a/src/loopmacros.rs
+++ b/src/loopmacros.rs
@@ -66,7 +66,6 @@ macro_rules! loop8 {
     }}
 }
 
-// AVX-512 sgemm microkernel (16 kernel rows)
 #[allow(unused)]
 #[cfg(debug_assertions)]
 macro_rules! loop16 {

--- a/src/packing.rs
+++ b/src/packing.rs
@@ -78,6 +78,18 @@ pub(crate) unsafe fn pack_avx2<MR, T>(kc: usize, mc: usize, pack: PackSlice<T>,
     pack_impl::<MR, T>(kc, mc, pack, a, rsa, csa)
 }
 
+/// Specialized for AVX-512
+/// Safety: Requires AVX-512F
+#[cfg(has_avx512)]
+#[target_feature(enable="avx512f")]
+pub(crate) unsafe fn pack_avx512<MR, T>(kc: usize, mc: usize, pack: &mut [T],
+                                        a: *const T, rsa: isize, csa: isize)
+    where T: Element,
+          MR: ConstNum,
+{
+    pack_impl::<MR, T>(kc, mc, pack, a, rsa, csa)
+}
+
 /// Pack implementation, see pack above for docs.
 ///
 /// Uses inline(always) so that it can be instantiated for different target features.

--- a/src/packing.rs
+++ b/src/packing.rs
@@ -82,7 +82,7 @@ pub(crate) unsafe fn pack_avx2<MR, T>(kc: usize, mc: usize, pack: PackSlice<T>,
 /// Safety: Requires AVX-512F
 #[cfg(has_avx512)]
 #[target_feature(enable="avx512f")]
-pub(crate) unsafe fn pack_avx512<MR, T>(kc: usize, mc: usize, pack: &mut [T],
+pub(crate) unsafe fn pack_avx512<MR, T>(kc: usize, mc: usize, pack: PackSlice<T>,
                                         a: *const T, rsa: isize, csa: isize)
     where T: Element,
           MR: ConstNum,

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -258,16 +258,16 @@ impl GemmKernel for KernelAvx512 {
     unsafe fn pack_mr(kc: usize, mc: usize, pack: &mut [Self::Elem],
                       a: *const Self::Elem, rsa: isize, csa: isize)
     {
-        // safety: any CPU with avx512f also has avx2
-        crate::packing::pack_avx2::<Self::MRTy, T>(kc, mc, pack, a, rsa, csa)
+        // safety: avx512f is enabled
+        crate::packing::pack_avx512::<Self::MRTy, T>(kc, mc, pack, a, rsa, csa)
     }
 
     #[inline]
     unsafe fn pack_nr(kc: usize, mc: usize, pack: &mut [Self::Elem],
                       a: *const Self::Elem, rsa: isize, csa: isize)
     {
-        // safety: any CPU with avx512f also has avx2
-        crate::packing::pack_avx2::<Self::NRTy, T>(kc, mc, pack, a, rsa, csa)
+        // safety: avx512f is enabled
+        crate::packing::pack_avx512::<Self::NRTy, T>(kc, mc, pack, a, rsa, csa)
     }
 
     #[inline(always)]

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -1070,14 +1070,8 @@ mod tests {
         }
 
         #[cfg(has_avx512)]
-        #[test]
-        fn avx512f() {
-            if is_x86_feature_detected_!("avx512f") {
-                test_a_kernel::<KernelAvx512, _>("avx512f");
-            } else {
-                #[cfg(feature = "std")]
-                println!("Skipping, host does not have feature: {:?}", "avx512f");
-            }
+        test_arch_kernels_x86! {
+            "avx512f", avx512f, KernelAvx512
         }
 
         #[test]

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -9,6 +9,8 @@
 use crate::kernel::GemmKernel;
 use crate::kernel::GemmSelect;
 use crate::kernel::{U4, U8};
+#[cfg(has_avx512)]
+use crate::kernel::U16;
 use crate::archparam;
 
 #[cfg(target_arch="x86")]
@@ -29,6 +31,8 @@ struct KernelFmaAvx2;
 struct KernelFma;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 struct KernelSse2;
+#[cfg(has_avx512)]
+struct KernelAvx512;
 
 #[cfg(target_arch="aarch64")]
 #[cfg(has_aarch64_simd)]
@@ -49,6 +53,12 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
     // dispatch to specific compiled versions
     #[cfg(any(target_arch="x86", target_arch="x86_64"))]
     {
+        #[cfg(has_avx512)]
+        {
+            if is_x86_feature_detected_!("avx512f") {
+                return selector.select(KernelAvx512);
+            }
+        }
         if is_x86_feature_detected_!("fma") {
             if is_x86_feature_detected_!("avx2") {
                 return selector.select(KernelFmaAvx2);
@@ -224,6 +234,37 @@ impl GemmKernel for KernelSse2 {
     }
 }
 
+#[cfg(has_avx512)]
+impl GemmKernel for KernelAvx512 {
+    type Elem = T;
+
+    type MRTy = U16;
+    type NRTy = U16;
+
+    #[inline(always)]
+    fn align_to() -> usize { 32 }
+
+    #[inline(always)]
+    fn always_masked() -> bool { false }
+
+    #[inline(always)]
+    fn nc() -> usize { archparam::S_NC }
+    #[inline(always)]
+    fn kc() -> usize { archparam::S_KC }
+    #[inline(always)]
+    fn mc() -> usize { archparam::S_MC }
+
+    #[inline(always)]
+    unsafe fn kernel(
+        k: usize,
+        alpha: T,
+        a: *const T,
+        b: *const T,
+        beta: T,
+        c: *mut T, rsc: isize, csc: isize) {
+        kernel_target_avx512(k, alpha, a, b, beta, c, rsc, csc)
+    }
+}
 
 #[cfg(target_arch="aarch64")]
 #[cfg(has_aarch64_simd)]
@@ -536,6 +577,68 @@ unsafe fn kernel_x86_avx<MA>(k: usize, alpha: T, a: *const T, b: *const T,
             _mm_store_ss(c![i, 6], cperm);
             let cperm = _mm_permute_ps(cperm, permute_mask!(0, 3, 2, 1));
             _mm_store_ss(c![i, 7], cperm);
+        });
+    }
+}
+
+// no inline for unmasked kernels
+#[cfg(has_avx512)]
+#[target_feature(enable="avx512f")]
+unsafe fn kernel_target_avx512(k: usize, alpha: T, a: *const T, b: *const T,
+                               beta: T, c: *mut T, rsc: isize, csc: isize)
+{
+    const MR: usize = KernelAvx512::MR;
+    const NR: usize = KernelAvx512::NR;
+    debug_assert_ne!(k, 0);
+
+    let mut ab = [_mm512_setzero_ps(); MR];
+
+    // Compute C in whichever orientation makes the output columns contiguous
+    let prefer_row_major_c = rsc != 1;
+    let (mut a, mut b) = if prefer_row_major_c { (a, b) } else { (b, a) };
+    let (rsc, csc) = if prefer_row_major_c { (rsc, csc) } else { (csc, rsc) };
+
+    // Compute A B. Load one 16-wide row of B, FMA against each broadcast A elem
+    let mut bv = _mm512_loadu_ps(b);
+    unroll_by_with_last!(4 => k, is_last, {
+        loop16!(i, ab[i] = _mm512_fmadd_ps(_mm512_set1_ps(*a.add(i)), bv, ab[i]));
+        if !is_last {
+            a = a.add(MR);
+            b = b.add(NR);
+            bv = _mm512_loadu_ps(b);
+        }
+    });
+
+    // ab = alpha * (A B)
+    let alphav = _mm512_set1_ps(alpha);
+    loop16!(i, ab[i] = _mm512_mul_ps(alphav, ab[i]));
+
+    macro_rules! c {
+        ($i:expr, $j:expr) => (c.offset(rsc * $i as isize + csc * $j as isize));
+    }
+
+    // ab = ab + beta * C
+    if beta != 0. {
+        let betav = _mm512_set1_ps(beta);
+        if csc == 1 {
+            loop16!(i, ab[i] = _mm512_fmadd_ps(_mm512_loadu_ps(c![i, 0]), betav, ab[i]));
+        } else {
+            loop16!(i, {
+                let mut tmp = [0.; NR];
+                for j in 0..NR { tmp[j] = *c![i, j]; }
+                ab[i] = _mm512_fmadd_ps(_mm512_loadu_ps(tmp.as_ptr()), betav, ab[i]);
+            });
+        }
+    }
+
+    // Store C back to memory
+    if csc == 1 {
+        loop16!(i, _mm512_storeu_ps(c![i, 0], ab[i]));
+    } else {
+        loop16!(i, {
+            let mut tmp = [0.; NR];
+            _mm512_storeu_ps(tmp.as_mut_ptr(), ab[i]);
+            for j in 0..NR { *c![i, j] = tmp[j]; }
         });
     }
 }
@@ -947,6 +1050,17 @@ mod tests {
             "sse2", sse2, KernelSse2
         }
 
+        #[cfg(has_avx512)]
+        #[test]
+        fn avx512f() {
+            if is_x86_feature_detected_!("avx512f") {
+                test_a_kernel::<KernelAvx512, _>("avx512f");
+            } else {
+                #[cfg(feature = "std")]
+                println!("Skipping, host does not have feature: {:?}", "avx512f");
+            }
+        }
+
         #[test]
         fn ensure_target_features_tested() {
             // If enabled, this test ensures that the requested feature actually
@@ -963,6 +1077,7 @@ mod tests {
                 "avx" => is_x86_feature_detected_!("avx"),
                 "fma" => is_x86_feature_detected_!("fma"),
                 "sse2" => is_x86_feature_detected_!("sse2"),
+                "avx512f" => is_x86_feature_detected_!("avx512f"),
                 _ => false,
             };
             assert!(detected, "Feature {:?} was not detected, so it could not be tested",

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -255,7 +255,7 @@ impl GemmKernel for KernelAvx512 {
     fn mc() -> usize { archparam::S_MC }
 
     #[inline]
-    unsafe fn pack_mr(kc: usize, mc: usize, pack: &mut [Self::Elem],
+    unsafe fn pack_mr(kc: usize, mc: usize, pack: PackSlice<Self::Elem>,
                       a: *const Self::Elem, rsa: isize, csa: isize)
     {
         // safety: avx512f is enabled
@@ -263,7 +263,7 @@ impl GemmKernel for KernelAvx512 {
     }
 
     #[inline]
-    unsafe fn pack_nr(kc: usize, mc: usize, pack: &mut [Self::Elem],
+    unsafe fn pack_nr(kc: usize, mc: usize, pack: PackSlice<Self::Elem>,
                       a: *const Self::Elem, rsa: isize, csa: isize)
     {
         // safety: avx512f is enabled

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -242,7 +242,7 @@ impl GemmKernel for KernelAvx512 {
     type NRTy = U16;
 
     #[inline(always)]
-    fn align_to() -> usize { 32 }
+    fn align_to() -> usize { 64 }
 
     #[inline(always)]
     fn always_masked() -> bool { false }
@@ -614,14 +614,14 @@ unsafe fn kernel_target_avx512(k: usize, alpha: T, a: *const T, b: *const T,
     let (mut a, mut b) = if prefer_row_major_c { (a, b) } else { (b, a) };
     let (rsc, csc) = if prefer_row_major_c { (rsc, csc) } else { (csc, rsc) };
 
-    // Compute A B. Load one 16-wide row of B, FMA against each broadcast A elem
-    let mut bv = _mm512_loadu_ps(b);
+    // Compute A B. The packed buffers are 64-byte aligned
+    let mut bv = _mm512_load_ps(b);
     unroll_by_with_last!(4 => k, is_last, {
         loop16!(i, ab[i] = _mm512_fmadd_ps(_mm512_set1_ps(*a.add(i)), bv, ab[i]));
         if !is_last {
             a = a.add(MR);
             b = b.add(NR);
-            bv = _mm512_loadu_ps(b);
+            bv = _mm512_load_ps(b);
         }
     });
 

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -254,6 +254,22 @@ impl GemmKernel for KernelAvx512 {
     #[inline(always)]
     fn mc() -> usize { archparam::S_MC }
 
+    #[inline]
+    unsafe fn pack_mr(kc: usize, mc: usize, pack: &mut [Self::Elem],
+                      a: *const Self::Elem, rsa: isize, csa: isize)
+    {
+        // safety: any CPU with avx512f also has avx2
+        crate::packing::pack_avx2::<Self::MRTy, T>(kc, mc, pack, a, rsa, csa)
+    }
+
+    #[inline]
+    unsafe fn pack_nr(kc: usize, mc: usize, pack: &mut [Self::Elem],
+                      a: *const Self::Elem, rsa: isize, csa: isize)
+    {
+        // safety: any CPU with avx512f also has avx2
+        crate::packing::pack_avx2::<Self::NRTy, T>(kc, mc, pack, a, rsa, csa)
+    }
+
     #[inline(always)]
     unsafe fn kernel(
         k: usize,
@@ -609,37 +625,40 @@ unsafe fn kernel_target_avx512(k: usize, alpha: T, a: *const T, b: *const T,
         }
     });
 
-    // ab = alpha * (A B)
-    let alphav = _mm512_set1_ps(alpha);
-    loop16!(i, ab[i] = _mm512_mul_ps(alphav, ab[i]));
-
     macro_rules! c {
         ($i:expr, $j:expr) => (c.offset(rsc * $i as isize + csc * $j as isize));
     }
 
-    // ab = ab + beta * C
+    // C <- alpha (A B) + beta C, in a single epilogue pass
+    // Fold alpha into the final FMA
+    // When beta == 0 the kernel must not read C
+    let alphav = _mm512_set1_ps(alpha);
     if beta != 0. {
         let betav = _mm512_set1_ps(beta);
         if csc == 1 {
-            loop16!(i, ab[i] = _mm512_fmadd_ps(_mm512_loadu_ps(c![i, 0]), betav, ab[i]));
+            loop16!(i, {
+                let cv = _mm512_mul_ps(_mm512_loadu_ps(c![i, 0]), betav);
+                _mm512_storeu_ps(c![i, 0], _mm512_fmadd_ps(alphav, ab[i], cv));
+            });
         } else {
             loop16!(i, {
                 let mut tmp = [0.; NR];
                 for j in 0..NR { tmp[j] = *c![i, j]; }
-                ab[i] = _mm512_fmadd_ps(_mm512_loadu_ps(tmp.as_ptr()), betav, ab[i]);
+                let cv = _mm512_mul_ps(_mm512_loadu_ps(tmp.as_ptr()), betav);
+                _mm512_storeu_ps(tmp.as_mut_ptr(), _mm512_fmadd_ps(alphav, ab[i], cv));
+                for j in 0..NR { *c![i, j] = tmp[j]; }
             });
         }
-    }
-
-    // Store C back to memory
-    if csc == 1 {
-        loop16!(i, _mm512_storeu_ps(c![i, 0], ab[i]));
     } else {
-        loop16!(i, {
-            let mut tmp = [0.; NR];
-            _mm512_storeu_ps(tmp.as_mut_ptr(), ab[i]);
-            for j in 0..NR { *c![i, j] = tmp[j]; }
-        });
+        if csc == 1 {
+            loop16!(i, _mm512_storeu_ps(c![i, 0], _mm512_mul_ps(alphav, ab[i])));
+        } else {
+            loop16!(i, {
+                let mut tmp = [0.; NR];
+                _mm512_storeu_ps(tmp.as_mut_ptr(), _mm512_mul_ps(alphav, ab[i]));
+                for j in 0..NR { *c![i, j] = tmp[j]; }
+            });
+        }
     }
 }
 

--- a/src/zgemm_kernel.rs
+++ b/src/zgemm_kernel.rs
@@ -349,14 +349,8 @@ mod tests {
         }
 
         #[cfg(has_avx512)]
-        #[test]
-        fn avx512f() {
-            if is_x86_feature_detected_!("avx512f") {
-                test_complex_packed_kernel::<KernelAvx512, _, TReal>("avx512f");
-            } else {
-                #[cfg(feature = "std")]
-                println!("Skipping, host does not have feature: {:?}", "avx512f");
-            }
+        test_arch_kernels_x86! {
+            "avx512f", avx512f, KernelAvx512
         }
     }
 }

--- a/src/zgemm_kernel.rs
+++ b/src/zgemm_kernel.rs
@@ -13,6 +13,8 @@ use crate::archparam;
 use crate::cgemm_common::pack_complex;
 use crate::packing::PackSlice;
 
+#[cfg(has_avx512)]
+struct KernelAvx512;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 struct KernelAvx2;
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
@@ -37,6 +39,12 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
     // dispatch to specific compiled versions
     #[cfg(any(target_arch="x86", target_arch="x86_64"))]
     {
+        #[cfg(has_avx512)]
+        {
+            if is_x86_feature_detected_!("avx512f") {
+                return selector.select(KernelAvx512);
+            }
+        }
         if is_x86_feature_detected_!("fma") {
             if is_x86_feature_detected_!("avx2") {
                 return selector.select(KernelAvx2);
@@ -56,6 +64,40 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
 
 macro_rules! loop_m { ($i:ident, $e:expr) => { loop4!($i, $e) }; }
 macro_rules! loop_n { ($j:ident, $e:expr) => { loop2!($j, $e) }; }
+
+#[cfg(has_avx512)]
+impl GemmKernel for KernelAvx512 {
+    type Elem = T;
+
+    type MRTy = U4;
+    type NRTy = U4;
+
+    #[inline(always)]
+    fn align_to() -> usize { 32 }
+
+    #[inline(always)]
+    fn always_masked() -> bool { KernelFallback::always_masked() }
+
+    #[inline(always)]
+    fn nc() -> usize { archparam::Z_NC }
+    #[inline(always)]
+    fn kc() -> usize { archparam::Z_KC }
+    #[inline(always)]
+    fn mc() -> usize { archparam::Z_MC }
+
+    pack_methods!{}
+
+    #[inline(always)]
+    unsafe fn kernel(
+        k: usize,
+        alpha: T,
+        a: *const T,
+        b: *const T,
+        beta: T,
+        c: *mut T, rsc: isize, csc: isize) {
+        kernel_target_avx512(k, alpha, a, b, beta, c, rsc, csc)
+    }
+}
 
 #[cfg(any(target_arch="x86", target_arch="x86_64"))]
 impl GemmKernel for KernelAvx2 {
@@ -223,6 +265,19 @@ kernel_fallback_impl_complex! {
     kernel_fallback_impl, T, TReal, KernelFallback::MR, KernelFallback::NR, 1
 }
 
+// 4x4 loop macros for AVX-512 only
+#[cfg(has_avx512)]
+macro_rules! loop_m { ($i:ident, $e:expr) => { loop4!($i, $e) }; }
+#[cfg(has_avx512)]
+macro_rules! loop_n { ($j:ident, $e:expr) => { loop4!($j, $e) }; }
+
+#[cfg(has_avx512)]
+kernel_fallback_impl_complex! {
+    // instantiate separately
+    [inline target_feature(enable="avx512f")] [fma_yes]
+    kernel_target_avx512, T, TReal, KernelAvx512::MR, KernelAvx512::NR, 4
+}
+
 #[inline(always)]
 unsafe fn at(ptr: *const TReal, i: usize) -> TReal {
     *ptr.add(i)
@@ -291,6 +346,17 @@ mod tests {
         test_arch_kernels_x86! {
             "fma", fma, KernelFma,
             "avx2", avx2, KernelAvx2
+        }
+
+        #[cfg(has_avx512)]
+        #[test]
+        fn avx512f() {
+            if is_x86_feature_detected_!("avx512f") {
+                test_complex_packed_kernel::<KernelAvx512, _, TReal>("avx512f");
+            } else {
+                #[cfg(feature = "std")]
+                println!("Skipping, host does not have feature: {:?}", "avx512f");
+            }
         }
     }
 }


### PR DESCRIPTION
Add runtime-dispatched AVX-512 kernels (gated `#[cfg(has_avx512)]`). When a CPU reports `avx512f` and the compiler is 1.89+, the dispatcher selects them automatically; otherwise behaviour is unchanged. The MSRV is not affected.

Measured single-thread on an AMD Ryzen 9 9950X (Zen 5), AVX-512 is basically the same as the FMA kernel across all sizes (f32 and f64): Zen 5 sustains the same peak FMA throughput whether it issues 4x256-bit or 2x512-bit FMAs per cycle (~64 f32 / ~32 f64 flop/cycle), and it runs 512-bit code at full boost (no down-clock).

A ~2x speedup is expected on cores with two 512-bit FMA units but only 2x256-bit for AVX2, i.e. Intel server parts (Skylake-SP, Cascade Lake, Ice Lake-SP, Sapphire Rapids). I don't have such hardware, so benchmarks from anyone who does are very welcome.