### PR TITLE
Raise MSRV to Rust 1.75

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.41.1  # MSRV
+          - rust: 1.75.0 # MSRV
             experimental: false
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            features: cgemm
+            features: threading cgemm
           - rust: stable
             experimental: false
             os: ubuntu-latest
@@ -101,7 +101,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.41.1  # MSRV
+          - rust: 1.75.0 # MSRV
             experimental: false
             target: thumbv6m-none-eabi
           - rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ categories = ["science"]
 exclude = ["examples/*", "ci/*", ".github/*", "benches/*"]
 
 build = "build.rs"
+rust-version = "1.75.0" # MSRV
 
 [lib]
 bench = false

--- a/build.rs
+++ b/build.rs
@@ -15,15 +15,8 @@ fn main() {
     // Avoid `unexpected_cfgs` lint from 1.80+ toolchains
     if ac.probe_rustc_version(1, 80) {
         println!("cargo:rustc-check-cfg=cfg(has_avx512)");
-        println!("cargo:rustc-check-cfg=cfg(has_aarch64_simd)");
     }
 
-    if target_arch == "aarch64" {
-        // From 1.61 aarch64 intrinsics and #[target_feature]
-        if ac.probe_rustc_version(1, 61) {
-            println!("cargo:rustc-cfg=has_aarch64_simd");
-        }
-    }
     if target_arch == "x86" || target_arch == "x86_64" {
         // From 1.89 AVX-512 intrinsics ("avx512f")
         if ac.probe_rustc_version(1, 89)

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,1 @@
-msrv = "1.41.1"
 too-many-arguments-threshold = 20

--- a/src/cgemm_kernel.rs
+++ b/src/cgemm_kernel.rs
@@ -24,7 +24,6 @@ struct KernelAvx2;
 struct KernelFma;
 
 #[cfg(target_arch = "aarch64")]
-#[cfg(has_aarch64_simd)]
 struct KernelNeon;
 
 struct KernelFallback;
@@ -56,7 +55,6 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
         }
     }
     #[cfg(target_arch = "aarch64")]
-    #[cfg(has_aarch64_simd)]
     {
         if is_aarch64_feature_detected_!("neon") {
             return selector.select(KernelNeon);
@@ -168,7 +166,6 @@ impl GemmKernel for KernelFma {
 }
 
 #[cfg(target_arch = "aarch64")]
-#[cfg(has_aarch64_simd)]
 impl GemmKernel for KernelNeon {
     type Elem = T;
 
@@ -278,14 +275,11 @@ kernel_fallback_impl_complex! {
 // Kernel neon
 
 #[cfg(target_arch = "aarch64")]
-#[cfg(has_aarch64_simd)]
 macro_rules! loop_m { ($i:ident, $e:expr) => { loop4!($i, $e) }; }
 #[cfg(target_arch = "aarch64")]
-#[cfg(has_aarch64_simd)]
 macro_rules! loop_n { ($j:ident, $e:expr) => { loop2!($j, $e) }; }
 
 #[cfg(target_arch = "aarch64")]
-#[cfg(has_aarch64_simd)]
 kernel_fallback_impl_complex! {
     [inline target_feature(enable="neon")] [fma_yes]
     kernel_target_neon, T, TReal, KernelNeon::MR, KernelNeon::NR, 1
@@ -312,7 +306,6 @@ mod tests {
     }
 
     #[cfg(target_arch = "aarch64")]
-    #[cfg(has_aarch64_simd)]
     mod test_kernel_aarch64 {
         use super::test_complex_packed_kernel;
         use super::super::*;

--- a/src/dgemm_kernel.rs
+++ b/src/dgemm_kernel.rs
@@ -37,7 +37,6 @@ struct KernelSse2;
 struct KernelAvx512;
 
 #[cfg(target_arch="aarch64")]
-#[cfg(has_aarch64_simd)]
 struct KernelNeon;
 
 struct KernelFallback;
@@ -73,7 +72,6 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
     }
 
     #[cfg(target_arch="aarch64")]
-    #[cfg(has_aarch64_simd)]
     {
         if is_aarch64_feature_detected_!("neon") {
             return selector.select(KernelNeon);
@@ -295,7 +293,6 @@ impl GemmKernel for KernelAvx512 {
 }
 
 #[cfg(target_arch="aarch64")]
-#[cfg(has_aarch64_simd)]
 impl GemmKernel for KernelNeon {
     type Elem = T;
 
@@ -1006,7 +1003,6 @@ unsafe fn kernel_target_avx512(k: usize, alpha: T, a: *const T, b: *const T,
 }
 
 #[cfg(target_arch="aarch64")]
-#[cfg(has_aarch64_simd)]
 #[target_feature(enable="neon")]
 unsafe fn kernel_target_neon(k: usize, alpha: T, a: *const T, b: *const T,
                              beta: T, c: *mut T, rsc: isize, csc: isize)
@@ -1186,7 +1182,6 @@ mod tests {
     }
 
     #[cfg(any(target_arch="aarch64"))]
-    #[cfg(has_aarch64_simd)]
     mod test_kernel_aarch64 {
         use super::test_a_kernel;
         use super::super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,14 +130,13 @@
 //! The functions in this crate are thread safe, as long as the destination
 //! matrix is distinct.
 //!
-//! ## Rust Version
+//! ## Rust Version (MSRV)
 //!
-//! This version requires Rust 1.41.1 or later; the crate follows a carefully
+//! This version requires Rust 1.75 or later; the crate follows a carefully
 //! considered upgrade policy, where updating the minimum Rust version is not a breaking
 //! change.
 //!
-//! Some features are enabled with later versions: from Rust 1.61 AArch64 NEON
-//! support, and from Rust 1.89 x86/x86-64 AVX-512 support.
+//! Some features are enabled with later versions: from Rust 1.89 x86/x86-64 AVX-512 support.
 
 #![doc(html_root_url = "https://docs.rs/matrixmultiply/0.3/")]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/src/sgemm_kernel.rs
+++ b/src/sgemm_kernel.rs
@@ -38,7 +38,6 @@ struct KernelSse2;
 struct KernelAvx512;
 
 #[cfg(target_arch="aarch64")]
-#[cfg(has_aarch64_simd)]
 struct KernelNeon;
 #[cfg(all(target_arch="wasm32", target_feature="simd128"))]
 struct KernelWasmSimd;
@@ -74,7 +73,6 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
         }
     }
     #[cfg(target_arch="aarch64")]
-    #[cfg(has_aarch64_simd)]
     {
         if is_aarch64_feature_detected_!("neon") {
             return selector.select(KernelNeon);
@@ -286,7 +284,6 @@ impl GemmKernel for KernelAvx512 {
 }
 
 #[cfg(target_arch="aarch64")]
-#[cfg(has_aarch64_simd)]
 impl GemmKernel for KernelNeon {
     type Elem = T;
 
@@ -661,7 +658,6 @@ unsafe fn kernel_target_avx512(k: usize, alpha: T, a: *const T, b: *const T,
 }
 
 #[cfg(target_arch="aarch64")]
-#[cfg(has_aarch64_simd)]
 #[target_feature(enable="neon")]
 unsafe fn kernel_target_neon(k: usize, alpha: T, a: *const T, b: *const T,
                              beta: T, c: *mut T, rsc: isize, csc: isize)
@@ -994,7 +990,6 @@ mod tests {
     }
 
     #[cfg(any(target_arch="aarch64"))]
-    #[cfg(has_aarch64_simd)]
     mod test_kernel_aarch64 {
         use super::test_a_kernel;
         use super::super::*;

--- a/src/zgemm_kernel.rs
+++ b/src/zgemm_kernel.rs
@@ -22,7 +22,6 @@ struct KernelAvx2;
 struct KernelFma;
 
 #[cfg(target_arch = "aarch64")]
-#[cfg(has_aarch64_simd)]
 struct KernelNeon;
 
 struct KernelFallback;
@@ -54,7 +53,6 @@ pub(crate) fn detect<G>(selector: G) where G: GemmSelect<T> {
         }
     }
     #[cfg(target_arch = "aarch64")]
-    #[cfg(has_aarch64_simd)]
     {
         if is_aarch64_feature_detected_!("neon") {
             return selector.select(KernelNeon);
@@ -169,7 +167,6 @@ impl GemmKernel for KernelFma {
 }
 
 #[cfg(target_arch = "aarch64")]
-#[cfg(has_aarch64_simd)]
 impl GemmKernel for KernelNeon {
     type Elem = T;
 
@@ -253,7 +250,6 @@ kernel_fallback_impl_complex! {
 // Kernel neon
 
 #[cfg(target_arch = "aarch64")]
-#[cfg(has_aarch64_simd)]
 kernel_fallback_impl_complex! {
     [inline target_feature(enable="neon")] [fma_yes]
     kernel_target_neon, T, TReal, KernelNeon::MR, KernelNeon::NR, 1
@@ -290,7 +286,6 @@ mod tests {
     }
 
     #[cfg(target_arch = "aarch64")]
-    #[cfg(has_aarch64_simd)]
     mod test_kernel_aarch64 {
         use super::test_complex_packed_kernel;
         use super::super::*;


### PR DESCRIPTION
So that we can use more const fn and const generics features.